### PR TITLE
Refactor NDEF handling into helper class

### DIFF
--- a/Anarcho/SimpleRead_iso14443a_uid/NdefHelper.cpp
+++ b/Anarcho/SimpleRead_iso14443a_uid/NdefHelper.cpp
@@ -1,0 +1,183 @@
+#include "NdefHelper.h"
+
+#include <ctype.h>
+
+bool NdefHelper::parseNextTlv(const uint8_t* start, const uint8_t* end, Tlv& out) const {
+        if (!start || start >= end) return false;
+        const uint8_t* p = start;
+
+        while (p < end && *p == 0x00) {
+                ++p;
+        }
+        if (p >= end) return false;
+
+        uint8_t tag = *p++;
+        if (tag == 0xFE) {
+                out.tag = 0xFE;
+                out.value = nullptr;
+                out.length = 0;
+                out.next = nullptr;
+                return true;
+        }
+
+        if (p >= end) return false;
+
+        size_t len = 0;
+        if (*p == 0xFF) {
+                ++p;
+                if (p + 1 >= end) return false;
+                len = ((size_t)p[0] << 8) | (size_t)p[1];
+                p += 2;
+        } else {
+                len = *p++;
+        }
+
+        if ((size_t)(end - p) < len) return false;
+
+        out.tag = tag;
+        out.value = p;
+        out.length = len;
+        const uint8_t* next = p + len;
+        out.next = (next < end) ? next : nullptr;
+        return true;
+}
+
+bool NdefHelper::findFirstNdefTlv(const uint8_t* data, size_t length, Tlv& out) const {
+        if (!data || length == 0) return false;
+        const uint8_t* cursor = data;
+        const uint8_t* end = data + length;
+        Tlv current;
+        while (parseNextTlv(cursor, end, current)) {
+                if (current.tag == 0x03) {
+                        out = current;
+                        return true;
+                }
+                if (current.tag == 0xFE || !current.next) {
+                        break;
+                }
+                cursor = current.next;
+        }
+        return false;
+}
+
+bool NdefHelper::parseFirstRecord(const uint8_t* msg, size_t msgLen, NdefRecord& rec) const {
+        if (!msg || msgLen < 3) return false;
+        const uint8_t* p = msg;
+
+        uint8_t hdr = *p++;
+        rec.mb = hdr & 0x80;
+        rec.me = hdr & 0x40;
+        bool cf = hdr & 0x20;
+        rec.sr = hdr & 0x10;
+        rec.il = hdr & 0x08;
+        rec.tnf = hdr & 0x07;
+        if (cf) return false;
+
+        if ((size_t)(msg + msgLen - p) < 1) return false;
+        rec.typeLen = *p++;
+
+        if (rec.sr) {
+                if ((size_t)(msg + msgLen - p) < 1) return false;
+                rec.payloadLen = *p++;
+        } else {
+                if ((size_t)(msg + msgLen - p) < 4) return false;
+                rec.payloadLen = ((uint32_t)p[0] << 24) |
+                                 ((uint32_t)p[1] << 16) |
+                                 ((uint32_t)p[2] << 8) |
+                                 (uint32_t)p[3];
+                p += 4;
+        }
+
+        if (rec.il) {
+                if ((size_t)(msg + msgLen - p) < 1) return false;
+                rec.idLen = *p++;
+        } else {
+                rec.idLen = 0;
+        }
+
+        if ((size_t)(msg + msgLen - p) < rec.typeLen) return false;
+        rec.type = p;
+        p += rec.typeLen;
+
+        if (rec.idLen) {
+                if ((size_t)(msg + msgLen - p) < rec.idLen) return false;
+                rec.id = p;
+                p += rec.idLen;
+        } else {
+                rec.id = nullptr;
+        }
+
+        if ((size_t)(msg + msgLen - p) < rec.payloadLen) return false;
+        rec.payload = p;
+        return true;
+}
+
+bool NdefHelper::isTextRecord(const NdefRecord& rec) const {
+        return rec.tnf == 0x01 &&
+               rec.typeLen == 1 &&
+               rec.type != nullptr &&
+               rec.type[0] == 'T';
+}
+
+void NdefHelper::decodeAndPrintTextRecord(const NdefRecord& r) const {
+        if (!isTextRecord(r)) {
+                return;
+        }
+        if (r.payloadLen < 1) {
+                Serial.println(F("Empty RTD/T payload"));
+                return;
+        }
+
+        uint8_t status = r.payload[0];
+        bool utf16 = (status & 0x80) != 0;
+        uint8_t langLen = (status & 0x3F);
+        if (r.payloadLen < (size_t)(1 + langLen)) {
+                Serial.println(F("RTD/T payload too short"));
+                return;
+        }
+
+        String lang;
+        for (uint8_t i = 0; i < langLen; ++i) {
+                lang += (char)r.payload[1 + i];
+        }
+        const uint8_t* textPtr = r.payload + 1 + langLen;
+        size_t textLen = r.payloadLen - 1 - langLen;
+
+        Serial.print(F("NDEF Text: ("));
+        Serial.print(utf16 ? F("UTF-16") : F("UTF-8"));
+        Serial.print(F(", "));
+        Serial.print(lang);
+        Serial.println(F(")"));
+        Serial.println(F("Text payload:"));
+        if (utf16) {
+                dumpHexAscii(textPtr, textLen);
+        } else {
+                for (size_t i = 0; i < textLen; ++i) {
+                        char c = (char)textPtr[i];
+                        Serial.print(isprint((unsigned char)c) ? c : '.');
+                }
+                Serial.println();
+        }
+}
+
+void NdefHelper::dumpHexAscii(const uint8_t* data, size_t len) const {
+        Serial.print(F("Data ("));
+        Serial.print(len);
+        Serial.println(F(" bytes):"));
+        for (size_t i = 0; i < len; i += 16) {
+                Serial.printf("%04u: ", (unsigned)i);
+                for (size_t j = 0; j < 16; ++j) {
+                        if (i + j < len) {
+                                Serial.printf("%02X ", data[i + j]);
+                        } else {
+                                Serial.print("   ");
+                        }
+                }
+                Serial.print(" | ");
+                for (size_t j = 0; j < 16 && (i + j) < len; ++j) {
+                        char c = (char)data[i + j];
+                        Serial.print(isprint((unsigned char)c) ? c : '.');
+                }
+                Serial.println();
+        }
+}

--- a/Anarcho/SimpleRead_iso14443a_uid/NdefHelper.h
+++ b/Anarcho/SimpleRead_iso14443a_uid/NdefHelper.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <Arduino.h>
+#include <stddef.h>
+#include <stdint.h>
+
+class NdefHelper {
+public:
+        struct Tlv {
+                uint8_t tag = 0;
+                const uint8_t* value = nullptr;
+                size_t length = 0;
+                const uint8_t* next = nullptr;
+        };
+
+        struct NdefRecord {
+                uint8_t tnf = 0;
+                bool mb = false;
+                bool me = false;
+                bool sr = false;
+                bool il = false;
+                uint8_t typeLen = 0;
+                uint32_t payloadLen = 0;
+                uint8_t idLen = 0;
+                const uint8_t* type = nullptr;
+                const uint8_t* id = nullptr;
+                const uint8_t* payload = nullptr;
+        };
+
+        bool findFirstNdefTlv(const uint8_t* data, size_t length, Tlv& out) const;
+        bool parseFirstRecord(const uint8_t* msg, size_t msgLen, NdefRecord& rec) const;
+        bool isTextRecord(const NdefRecord& rec) const;
+        void decodeAndPrintTextRecord(const NdefRecord& rec) const;
+        void dumpHexAscii(const uint8_t* data, size_t len) const;
+
+private:
+        bool parseNextTlv(const uint8_t* start, const uint8_t* end, Tlv& out) const;
+};

--- a/Anarcho/SimpleRead_iso14443a_uid/SimpleRead_iso14443a_uid.ino
+++ b/Anarcho/SimpleRead_iso14443a_uid/SimpleRead_iso14443a_uid.ino
@@ -16,8 +16,9 @@
 
 #include <PN532_HSU.h>
 #include <PN532.h>
-#include <ctype.h>
 #include <string.h>
+
+#include "NdefHelper.h"
 
 #define PN532_HSU_PORT   Serial2
 static const uint32_t PN532_HSU_BAUDRATE = 115200;
@@ -29,10 +30,12 @@ static PN532     nfc(pn532hsu);
 
 namespace {
 
-	constexpr uint8_t  kUidBufferMax = 10;    // 4/7/10 Byte UIDs
-	constexpr uint16_t kUserMaxBytes = 1024;  // reicht für NTAG216 (888 B)
-	constexpr uint8_t  kBytesPerPage = 4;
-	constexpr uint8_t  kFirstUserPage = 4;
+        constexpr uint8_t  kUidBufferMax = 10;    // 4/7/10 Byte UIDs
+        constexpr uint16_t kUserMaxBytes = 1024;  // reicht für NTAG216 (888 B)
+        constexpr uint8_t  kBytesPerPage = 4;
+        constexpr uint8_t  kFirstUserPage = 4;
+
+        static NdefHelper ndefHelper;
 
 	struct TagInfo {
 		bool     ccValid = false;
@@ -46,26 +49,9 @@ namespace {
 		const char* probableType = "Unknown Type 2";
 	};
 
-	bool isSameUid(const uint8_t* lhs, const uint8_t* rhs, uint8_t len) {
-		return lhs && rhs && (memcmp(lhs, rhs, len) == 0);
-	}
-
-	void dumpHexAscii(const uint8_t* data, size_t len) {
-		Serial.print(F("Data (")); Serial.print(len); Serial.println(F(" bytes):"));
-		for (size_t i = 0; i < len; i += 16) {
-			Serial.printf("%04u: ", (unsigned)i);
-			for (size_t j = 0; j < 16; ++j) {
-				if (i + j < len) Serial.printf("%02X ", data[i + j]);
-				else             Serial.print("   ");
-			}
-			Serial.print(" | ");
-			for (size_t j = 0; j < 16 && (i + j) < len; ++j) {
-				char c = (char)data[i + j];
-				Serial.print(isprint((unsigned char)c) ? c : '.');
-			}
-			Serial.println();
-		}
-	}
+        bool isSameUid(const uint8_t* lhs, const uint8_t* rhs, uint8_t len) {
+                return lhs && rhs && (memcmp(lhs, rhs, len) == 0);
+        }
 
 	/* ---------- CC lesen (Page 3) und TagInfo ableiten ---------- */
 	bool readCapabilityContainer(TagInfo& out) {
@@ -109,117 +95,6 @@ namespace {
 			}
 		}
 		return true;
-	}
-
-	/* ---------- TLV Parsing ---------- */
-	struct Tlv {
-		uint8_t tag;
-		const uint8_t* value;
-		size_t length;
-		const uint8_t* next;
-	};
-
-	bool parseNextTlv(const uint8_t* start, const uint8_t* end, Tlv& out) {
-		if (!start || start >= end) return false;
-		const uint8_t* p = start;
-
-		while (p < end && *p == 0x00) ++p; // NULL TLVs
-		if (p >= end) return false;
-
-		uint8_t tag = *p++;
-		if (tag == 0xFE) { // Terminator
-			out.tag = 0xFE; out.value = nullptr; out.length = 0; out.next = nullptr;
-			return true;
-		}
-
-		if (p >= end) return false;
-
-		size_t len = 0;
-		if (*p == 0xFF) { // extended length
-			++p; if (p + 1 >= end) return false;
-			len = ((size_t)p[0] << 8) | (size_t)p[1]; p += 2;
-		}
-		else {
-			len = *p++;
-		}
-
-		if ((size_t)(end - p) < len) return false;
-
-		out.tag = tag; out.value = p; out.length = len;
-		const uint8_t* next = p + len;
-		out.next = (next < end) ? next : nullptr;
-		return true;
-	}
-
-	/* ---------- NDEF Parsing (erster Record) ---------- */
-	struct NdefRecord {
-		uint8_t tnf; bool mb; bool me; bool sr; bool il;
-		uint8_t  typeLen; uint32_t payloadLen; uint8_t idLen;
-		const uint8_t* type; const uint8_t* id; const uint8_t* payload;
-	};
-
-	bool parseFirstNdefRecord(const uint8_t* msg, size_t msgLen, NdefRecord& rec) {
-		if (!msg || msgLen < 3) return false;
-		const uint8_t* p = msg;
-
-		uint8_t hdr = *p++;
-		rec.mb = hdr & 0x80; rec.me = hdr & 0x40;
-		bool cf = hdr & 0x20; rec.sr = hdr & 0x10; rec.il = hdr & 0x08;
-		rec.tnf = hdr & 0x07;
-		if (cf) return false; // keine Chunk-Unterstützung
-
-		if ((size_t)(msg + msgLen - p) < 1) return false;
-		rec.typeLen = *p++;
-
-		if (rec.sr) {
-			if ((size_t)(msg + msgLen - p) < 1) return false;
-			rec.payloadLen = *p++;
-		}
-		else {
-			if ((size_t)(msg + msgLen - p) < 4) return false;
-			rec.payloadLen = ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
-				((uint32_t)p[2] << 8) | ((uint32_t)p[3]); p += 4;
-		}
-
-		if (rec.il) { if ((size_t)(msg + msgLen - p) < 1) return false; rec.idLen = *p++; }
-		else rec.idLen = 0;
-
-		if ((size_t)(msg + msgLen - p) < rec.typeLen) return false;
-		rec.type = p; p += rec.typeLen;
-
-		if (rec.idLen) { if ((size_t)(msg + msgLen - p) < rec.idLen) return false; rec.id = p; p += rec.idLen; }
-		else rec.id = nullptr;
-
-		if ((size_t)(msg + msgLen - p) < rec.payloadLen) return false;
-		rec.payload = p;
-		return true;
-	}
-
-	void decodeAndPrintTextRecord(const NdefRecord& r) {
-		if (!(r.tnf == 0x01 && r.typeLen == 1 && r.type && r.type[0] == 'T')) return;
-		if (r.payloadLen < 1) { Serial.println(F("Empty RTD/T payload")); return; }
-
-		uint8_t status = r.payload[0];
-		bool utf16 = (status & 0x80) != 0;
-		uint8_t langLen = (status & 0x3F);
-		if (r.payloadLen < (size_t)(1 + langLen)) { Serial.println(F("RTD/T payload too short")); return; }
-
-		String lang; for (uint8_t i = 0; i < langLen; ++i) lang += (char)r.payload[1 + i];
-		const uint8_t* textPtr = r.payload + 1 + langLen;
-		size_t textLen = r.payloadLen - 1 - langLen;
-
-		Serial.print(F("NDEF Text: ("));
-		Serial.print(utf16 ? F("UTF-16") : F("UTF-8"));
-		Serial.print(F(", ")); Serial.print(lang); Serial.println(F(")"));
-		Serial.println(F("Text payload:"));
-		if (utf16) dumpHexAscii(textPtr, textLen);
-		else {
-			for (size_t i = 0; i < textLen; ++i) {
-				char c = (char)textPtr[i];
-				Serial.print(isprint((unsigned char)c) ? c : '.');
-			}
-			Serial.println();
-		}
 	}
 
 } // namespace
@@ -303,42 +178,33 @@ void loop() {
 				return;
 			}
 
-			// Optional: Rohdump
-			// dumpHexAscii(user, ti.userBytes);
+                        // Optional: Rohdump
+                        // ndefHelper.dumpHexAscii(user, ti.userBytes);
 
-			// --- 3) TLV scannen: NDEF (0x03) finden ---
-			const uint8_t* p = user;
-			const uint8_t* end = user + ti.userBytes;
-
-			Tlv tlv{};
-			bool foundNdef = false;
-			while (parseNextTlv(p, end, tlv)) {
-				if (tlv.tag == 0x03) { foundNdef = true; break; }
-				if (tlv.tag == 0xFE) break;
-				if (!tlv.next) break;
-				p = tlv.next;
-			}
+                        // --- 3) TLV scannen: NDEF (0x03) finden ---
+                        NdefHelper::Tlv tlv{};
+                        bool foundNdef = ndefHelper.findFirstNdefTlv(user, ti.userBytes, tlv);
 
 			if (foundNdef) {
 				Serial.print(F("NDEF length (TLV): "));
 				Serial.println((unsigned)tlv.length);
 
-				// --- 4) Ersten NDEF-Record parsen & bei Text ausgeben ---
-				NdefRecord rec{};
-				if (parseFirstNdefRecord(tlv.value, tlv.length, rec)) {
-					// Wenn es ein Text-Record ist, gib den Text direkt aus (wie bei dir genutzt)
-					if (rec.tnf == 0x01 && rec.typeLen == 1 && rec.type && rec.type[0] == 'T') {
-						decodeAndPrintTextRecord(rec);
-					}
-					else {
-						Serial.println(F("First NDEF record is not a Text (RTD/T) record."));
-						Serial.println(F("Record header / payload (hex):"));
-						dumpHexAscii(tlv.value, tlv.length);
-					}
-				}
-				else {
-					Serial.println(F("Failed to parse first NDEF record"));
-				}
+                                // --- 4) Ersten NDEF-Record parsen & bei Text ausgeben ---
+                                NdefHelper::NdefRecord rec{};
+                                if (ndefHelper.parseFirstRecord(tlv.value, tlv.length, rec)) {
+                                        // Wenn es ein Text-Record ist, gib den Text direkt aus (wie bei dir genutzt)
+                                        if (ndefHelper.isTextRecord(rec)) {
+                                                ndefHelper.decodeAndPrintTextRecord(rec);
+                                        }
+                                        else {
+                                                Serial.println(F("First NDEF record is not a Text (RTD/T) record."));
+                                                Serial.println(F("Record header / payload (hex):"));
+                                                ndefHelper.dumpHexAscii(tlv.value, tlv.length);
+                                        }
+                                }
+                                else {
+                                        Serial.println(F("Failed to parse first NDEF record"));
+                                }
 			}
 			else {
 				Serial.println(F("No NDEF TLV found (0x03)"));

--- a/Anarcho/SimpleRead_iso14443a_uid/SimpleRead_iso14443a_uid.vcxproj
+++ b/Anarcho/SimpleRead_iso14443a_uid/SimpleRead_iso14443a_uid.vcxproj
@@ -78,8 +78,12 @@
       <FileType>CppCode</FileType>
       <DeploymentContent>true</DeploymentContent>
     </ClCompile>
+    <ClCompile Include="NdefHelper.cpp">
+      <FileType>CppCode</FileType>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="NdefHelper.h" />
     <ClInclude Include="__vm\.SimpleRead_iso14443a_uid.vsarduino.h" />
   </ItemGroup>
   <PropertyGroup>

--- a/Anarcho/SimpleRead_iso14443a_uid/SimpleRead_iso14443a_uid.vcxproj.filters
+++ b/Anarcho/SimpleRead_iso14443a_uid/SimpleRead_iso14443a_uid.vcxproj.filters
@@ -16,8 +16,14 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="SimpleRead_iso14443a_uid.ino" />
+    <ClCompile Include="NdefHelper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="NdefHelper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="__vm\.SimpleRead_iso14443a_uid.vsarduino.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
## Summary
- extract TLV and NDEF parsing/printing into a reusable `NdefHelper` class
- update `SimpleRead_iso14443a_uid.ino` to delegate NDEF work to the helper while keeping existing behaviour
- register the new helper files with the Visual Micro project configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf18b3ffc48323945e8244a7f0bee0