### PR TITLE
Apply Allman formatting to ESP32 NMCI project

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -6,152 +6,182 @@
   TLV-Parsing, NDEF-Parsing (erster Record) optional Textausgabe.
 
   Verkabelung (HSU/UART):
-	ESP32 TX (GPIO 25) → PN532 RX
-	ESP32 RX (GPIO 26) → PN532 TX
-	3,3V Pegel, PN532 auf HSU/UART gestellt
+        ESP32 TX (GPIO 25) → PN532 RX
+        ESP32 RX (GPIO 26) → PN532 TX
+        3,3V Pegel, PN532 auf HSU/UART gestellt
 
   Serielle Ausgabe: 115200 Baud
 */
 /**************************************************************************/
 
-#include <PN532_HSU.h>
 #include <PN532.h>
+#include <PN532_HSU.h>
 #include <string.h>
 
 #include "NdefHelper.h"
 #include "Type2TagReader.h"
 
-#define PN532_HSU_PORT   Serial2
+#define PN532_HSU_PORT Serial2
 static const uint32_t PN532_HSU_BAUDRATE = 115200;
-static const int      PN532_HSU_RX_PIN = 26;  // ESP32 RX  (an PN532 TX)
-static const int      PN532_HSU_TX_PIN = 25;  // ESP32 TX  (an PN532 RX)
+static const int PN532_HSU_RX_PIN = 26; // ESP32 RX  (an PN532 TX)
+static const int PN532_HSU_TX_PIN = 25; // ESP32 TX  (an PN532 RX)
 
 static PN532_HSU pn532hsu(PN532_HSU_PORT);
-static PN532     nfc(pn532hsu);
+static PN532 nfc(pn532hsu);
 static Type2TagReader tagReader(nfc);
 
-constexpr uint8_t  kUidBufferMax = 10;    // 4/7/10 Byte UIDs
-constexpr uint16_t kUserMaxBytes = 1024;  // reicht für NTAG216 (888 B)
+constexpr uint8_t kUidBufferMax = 10;    // 4/7/10 Byte UIDs
+constexpr uint16_t kUserMaxBytes = 1024; // reicht für NTAG216 (888 B)
 
 static NdefHelper ndefHelper;
 
-void setup() {
-	Serial.begin(115200);
-	while (!Serial) { delay(10); }
+void setup()
+{
+        Serial.begin(115200);
+        while (!Serial)
+        {
+                delay(10);
+        }
 
-	PN532_HSU_PORT.begin(PN532_HSU_BAUDRATE, SERIAL_8N1,
-		PN532_HSU_RX_PIN, PN532_HSU_TX_PIN);
+        PN532_HSU_PORT.begin(PN532_HSU_BAUDRATE, SERIAL_8N1,
+                             PN532_HSU_RX_PIN, PN532_HSU_TX_PIN);
 
-	nfc.begin();
+        nfc.begin();
 
-	uint32_t versiondata = nfc.getFirmwareVersion();
-	if (!versiondata) {
-		Serial.println(F("PN532 not found (check wiring & HSU mode)"));
-		while (true) { delay(1000); }
-	}
+        uint32_t versiondata = nfc.getFirmwareVersion();
+        if (!versiondata)
+        {
+                Serial.println(F("PN532 not found (check wiring & HSU mode)"));
+                while (true)
+                {
+                        delay(1000);
+                }
+        }
 
-	Serial.print(F("Found chip PN5"));
-	Serial.println((versiondata >> 24) & 0xFF, HEX);
-	Serial.print(F("Firmware ver. "));
-	Serial.print((versiondata >> 16) & 0xFF, DEC);
-	Serial.print('.');
-	Serial.println((versiondata >> 8) & 0xFF, DEC);
+        Serial.print(F("Found chip PN5"));
+        Serial.println((versiondata >> 24) & 0xFF, HEX);
+        Serial.print(F("Firmware ver. "));
+        Serial.print((versiondata >> 16) & 0xFF, DEC);
+        Serial.print('.');
+        Serial.println((versiondata >> 8) & 0xFF, DEC);
 
-	nfc.SAMConfig();
-	nfc.setPassiveActivationRetries(0xFF);
+        nfc.SAMConfig();
+        nfc.setPassiveActivationRetries(0xFF);
 
-	Serial.println(F("Waiting for an ISO14443A Card ..."));
+        Serial.println(F("Waiting for an ISO14443A Card ..."));
 }
 
-void loop() {
-	static uint8_t lastUid[kUidBufferMax] = { 0 };
-	static uint8_t lastUidLength = 0;
-	static bool    tagPresent = false;
+void loop()
+{
+        static uint8_t lastUid[kUidBufferMax] = {0};
+        static uint8_t lastUidLength = 0;
+        static bool tagPresent = false;
 
-	uint8_t uid[kUidBufferMax] = { 0 };
-	uint8_t uidLength = 0;
+        uint8_t uid[kUidBufferMax] = {0};
+        uint8_t uidLength = 0;
 
-	if (nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength)) {
-		bool newTagDetected = (!tagPresent) ||
-			(uidLength != lastUidLength) ||
-			(!Type2TagReader::isSameUid(uid, lastUid, uidLength));
+        if (nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength))
+        {
+                bool newTagDetected = (!tagPresent) ||
+                                      (uidLength != lastUidLength) ||
+                                      (!Type2TagReader::isSameUid(uid, lastUid, uidLength));
 
-		if (newTagDetected) {
-			tagPresent = true;
-			lastUidLength = uidLength;
-			memcpy(lastUid, uid, uidLength);
+                if (newTagDetected)
+                {
+                        tagPresent = true;
+                        lastUidLength = uidLength;
+                        memcpy(lastUid, uid, uidLength);
 
-			Serial.print(F("Tag detected. UID length: "));
-			Serial.println(uidLength);
-			Serial.print(F("UID: ")); nfc.PrintHex(uid, uidLength);
+                        Serial.print(F("Tag detected. UID length: "));
+                        Serial.println(uidLength);
+                        Serial.print(F("UID: "));
+                        nfc.PrintHex(uid, uidLength);
 
-			// --- 1) CC lesen & interpretieren ---
-			Type2TagReader::TagInfo ti{};
-			if (!tagReader.readCapabilityContainer(ti)) {
-				Serial.println(F("Failed to read Capability Container (page 3)"));
-				return;
-			}
+                        // --- 1) CC lesen & interpretieren ---
+                        Type2TagReader::TagInfo ti{};
+                        if (!tagReader.readCapabilityContainer(ti))
+                        {
+                                Serial.println(F("Failed to read Capability Container (page 3)"));
+                                return;
+                        }
 
-			Serial.print(F("CC: Magic=0x")); Serial.print(ti.ccMagic, HEX);
-			Serial.print(F(", Ver=")); Serial.print(ti.verMaj); Serial.print('.'); Serial.print(ti.verMin);
-			Serial.print(F(", Size8=0x")); Serial.print(ti.size8, HEX);
-			Serial.print(F(" (")); Serial.print(ti.userBytes); Serial.print(F(" bytes user)"));
-			Serial.print(F(", Access=0x")); Serial.print(ti.access, HEX);
-			Serial.println();
+                        Serial.print(F("CC: Magic=0x"));
+                        Serial.print(ti.ccMagic, HEX);
+                        Serial.print(F(", Ver="));
+                        Serial.print(ti.verMaj);
+                        Serial.print('.');
+                        Serial.print(ti.verMin);
+                        Serial.print(F(", Size8=0x"));
+                        Serial.print(ti.size8, HEX);
+                        Serial.print(F(" ("));
+                        Serial.print(ti.userBytes);
+                        Serial.print(F(" bytes user)"));
+                        Serial.print(F(", Access=0x"));
+                        Serial.print(ti.access, HEX);
+                        Serial.println();
 
-			if (!ti.ccValid) {
-				Serial.println(F("Warning: CC Magic != 0xE1 (evtl. kein NDEF-Tag oder CC korrupt)"));
-			}
+                        if (!ti.ccValid)
+                        {
+                                Serial.println(F("Warning: CC Magic != 0xE1 (evtl. kein NDEF-Tag oder CC korrupt)"));
+                        }
 
-			Serial.print(F("Probable type: "));
-			Serial.println(ti.probableType);
+                        Serial.print(F("Probable type: "));
+                        Serial.println(ti.probableType);
 
-			// --- 2) User Memory vollständig lesen (dynamisch) ---
-			static uint8_t user[kUserMaxBytes];
-			if (!tagReader.readUserMemory(user, sizeof(user), ti)) {
-				Serial.println(F("Failed to read user memory"));
-				return;
-			}
+                        // --- 2) User Memory vollständig lesen (dynamisch) ---
+                        static uint8_t user[kUserMaxBytes];
+                        if (!tagReader.readUserMemory(user, sizeof(user), ti))
+                        {
+                                Serial.println(F("Failed to read user memory"));
+                                return;
+                        }
 
-			// Optional: Rohdump
-			// ndefHelper.dumpHexAscii(user, ti.userBytes);
+                        // Optional: Rohdump
+                        // ndefHelper.dumpHexAscii(user, ti.userBytes);
 
-			// --- 3) TLV scannen: NDEF (0x03) finden ---
-			NdefHelper::Tlv tlv{};
-			bool foundNdef = ndefHelper.findFirstNdefTlv(user, ti.userBytes, tlv);
+                        // --- 3) TLV scannen: NDEF (0x03) finden ---
+                        NdefHelper::Tlv tlv{};
+                        bool foundNdef = ndefHelper.findFirstNdefTlv(user, ti.userBytes, tlv);
 
-			if (foundNdef) {
-				Serial.print(F("NDEF length (TLV): "));
-				Serial.println((unsigned)tlv.length);
+                        if (foundNdef)
+                        {
+                                Serial.print(F("NDEF length (TLV): "));
+                                Serial.println((unsigned)tlv.length);
 
-				// --- 4) Ersten NDEF-Record parsen & bei Text ausgeben ---
-				NdefHelper::NdefRecord rec{};
-				if (ndefHelper.parseFirstRecord(tlv.value, tlv.length, rec)) {
-					// Wenn es ein Text-Record ist, gib den Text direkt aus (wie bei dir genutzt)
-					if (ndefHelper.isTextRecord(rec)) {
-						ndefHelper.decodeAndPrintTextRecord(rec);
-					}
-					else {
-						Serial.println(F("First NDEF record is not a Text (RTD/T) record."));
-						Serial.println(F("Record header / payload (hex):"));
-						ndefHelper.dumpHexAscii(tlv.value, tlv.length);
-					}
-				}
-				else {
-					Serial.println(F("Failed to parse first NDEF record"));
-				}
-			}
-			else {
-				Serial.println(F("No NDEF TLV found (0x03)"));
-			}
-		}
-	}
-	else if (tagPresent) {
-		tagPresent = false;
-		lastUidLength = 0;
-		memset(lastUid, 0, sizeof(lastUid));
-		Serial.println(F("Tag removed"));
-	}
+                                // --- 4) Ersten NDEF-Record parsen & bei Text ausgeben ---
+                                NdefHelper::NdefRecord rec{};
+                                if (ndefHelper.parseFirstRecord(tlv.value, tlv.length, rec))
+                                {
+                                        // Wenn es ein Text-Record ist, gib den Text direkt aus (wie bei dir genutzt)
+                                        if (ndefHelper.isTextRecord(rec))
+                                        {
+                                                ndefHelper.decodeAndPrintTextRecord(rec);
+                                        }
+                                        else
+                                        {
+                                                Serial.println(F("First NDEF record is not a Text (RTD/T) record."));
+                                                Serial.println(F("Record header / payload (hex):"));
+                                                ndefHelper.dumpHexAscii(tlv.value, tlv.length);
+                                        }
+                                }
+                                else
+                                {
+                                        Serial.println(F("Failed to parse first NDEF record"));
+                                }
+                        }
+                        else
+                        {
+                                Serial.println(F("No NDEF TLV found (0x03)"));
+                        }
+                }
+        }
+        else if (tagPresent)
+        {
+                tagPresent = false;
+                lastUidLength = 0;
+                memset(lastUid, 0, sizeof(lastUid));
+                Serial.println(F("Tag removed"));
+        }
 
-	delay(250);
+        delay(250);
 }

--- a/Src/Esp32NMCI/NdefHelper.cpp
+++ b/Src/Esp32NMCI/NdefHelper.cpp
@@ -1,188 +1,234 @@
 #include "NdefHelper.h"
 #include <ctype.h>
 
-bool NdefHelper::parseNextTlv(const uint8_t* start, const uint8_t* end, Tlv& out) const {
-	if (!start || start >= end) return false;
-	const uint8_t* p = start;
+bool NdefHelper::parseNextTlv(const uint8_t* start, const uint8_t* end, Tlv& out) const
+{
+        if (!start || start >= end)
+                return false;
+        const uint8_t* p = start;
 
-	while (p < end && *p == 0x00) {
-		++p;
-	}
-	if (p >= end) return false;
+        while (p < end && *p == 0x00)
+        {
+                ++p;
+        }
+        if (p >= end)
+                return false;
 
-	uint8_t tag = *p++;
-	if (tag == 0xFE) {
-		out.tag = 0xFE;
-		out.value = nullptr;
-		out.length = 0;
-		out.next = nullptr;
-		return true;
-	}
+        uint8_t tag = *p++;
+        if (tag == 0xFE)
+        {
+                out.tag = 0xFE;
+                out.value = nullptr;
+                out.length = 0;
+                out.next = nullptr;
+                return true;
+        }
 
-	if (p >= end) return false;
+        if (p >= end)
+                return false;
 
-	size_t len = 0;
-	if (*p == 0xFF) {
-		++p;
-		if (p + 1 >= end) return false;
-		len = ((size_t)p[0] << 8) | (size_t)p[1];
-		p += 2;
-	}
-	else {
-		len = *p++;
-	}
+        size_t len = 0;
+        if (*p == 0xFF)
+        {
+                ++p;
+                if (p + 1 >= end)
+                        return false;
+                len = ((size_t)p[0] << 8) | (size_t)p[1];
+                p += 2;
+        }
+        else
+        {
+                len = *p++;
+        }
 
-	if ((size_t)(end - p) < len) return false;
+        if ((size_t)(end - p) < len)
+                return false;
 
-	out.tag = tag;
-	out.value = p;
-	out.length = len;
-	const uint8_t* next = p + len;
-	out.next = (next < end) ? next : nullptr;
-	return true;
+        out.tag = tag;
+        out.value = p;
+        out.length = len;
+        const uint8_t* next = p + len;
+        out.next = (next < end) ? next : nullptr;
+        return true;
 }
 
-bool NdefHelper::findFirstNdefTlv(const uint8_t* data, size_t length, Tlv& out) const {
-	if (!data || length == 0) return false;
-	const uint8_t* cursor = data;
-	const uint8_t* end = data + length;
-	Tlv current;
-	while (parseNextTlv(cursor, end, current)) {
-		if (current.tag == 0x03) {
-			out = current;
-			return true;
-		}
-		if (current.tag == 0xFE || !current.next) {
-			break;
-		}
-		cursor = current.next;
-	}
-	return false;
+bool NdefHelper::findFirstNdefTlv(const uint8_t* data, size_t length, Tlv& out) const
+{
+        if (!data || length == 0)
+                return false;
+        const uint8_t* cursor = data;
+        const uint8_t* end = data + length;
+        Tlv current;
+        while (parseNextTlv(cursor, end, current))
+        {
+                if (current.tag == 0x03)
+                {
+                        out = current;
+                        return true;
+                }
+                if (current.tag == 0xFE || !current.next)
+                {
+                        break;
+                }
+                cursor = current.next;
+        }
+        return false;
 }
 
-bool NdefHelper::parseFirstRecord(const uint8_t* msg, size_t msgLen, NdefRecord& rec) const {
-	if (!msg || msgLen < 3) return false;
-	const uint8_t* p = msg;
+bool NdefHelper::parseFirstRecord(const uint8_t* msg, size_t msgLen, NdefRecord& rec) const
+{
+        if (!msg || msgLen < 3)
+                return false;
+        const uint8_t* p = msg;
 
-	uint8_t hdr = *p++;
-	rec.mb = hdr & 0x80;
-	rec.me = hdr & 0x40;
-	bool cf = hdr & 0x20;
-	rec.sr = hdr & 0x10;
-	rec.il = hdr & 0x08;
-	rec.tnf = hdr & 0x07;
-	if (cf) return false;
+        uint8_t hdr = *p++;
+        rec.mb = hdr & 0x80;
+        rec.me = hdr & 0x40;
+        bool cf = hdr & 0x20;
+        rec.sr = hdr & 0x10;
+        rec.il = hdr & 0x08;
+        rec.tnf = hdr & 0x07;
+        if (cf)
+                return false;
 
-	if ((size_t)(msg + msgLen - p) < 1) return false;
-	rec.typeLen = *p++;
+        if ((size_t)(msg + msgLen - p) < 1)
+                return false;
+        rec.typeLen = *p++;
 
-	if (rec.sr) {
-		if ((size_t)(msg + msgLen - p) < 1) return false;
-		rec.payloadLen = *p++;
-	}
-	else {
-		if ((size_t)(msg + msgLen - p) < 4) return false;
-		rec.payloadLen = ((uint32_t)p[0] << 24) |
-			((uint32_t)p[1] << 16) |
-			((uint32_t)p[2] << 8) |
-			(uint32_t)p[3];
-		p += 4;
-	}
+        if (rec.sr)
+        {
+                if ((size_t)(msg + msgLen - p) < 1)
+                        return false;
+                rec.payloadLen = *p++;
+        }
+        else
+        {
+                if ((size_t)(msg + msgLen - p) < 4)
+                        return false;
+                rec.payloadLen = ((uint32_t)p[0] << 24) |
+                                 ((uint32_t)p[1] << 16) |
+                                 ((uint32_t)p[2] << 8) |
+                                 (uint32_t)p[3];
+                p += 4;
+        }
 
-	if (rec.il) {
-		if ((size_t)(msg + msgLen - p) < 1) return false;
-		rec.idLen = *p++;
-	}
-	else {
-		rec.idLen = 0;
-	}
+        if (rec.il)
+        {
+                if ((size_t)(msg + msgLen - p) < 1)
+                        return false;
+                rec.idLen = *p++;
+        }
+        else
+        {
+                rec.idLen = 0;
+        }
 
-	if ((size_t)(msg + msgLen - p) < rec.typeLen) return false;
-	rec.type = p;
-	p += rec.typeLen;
+        if ((size_t)(msg + msgLen - p) < rec.typeLen)
+                return false;
+        rec.type = p;
+        p += rec.typeLen;
 
-	if (rec.idLen) {
-		if ((size_t)(msg + msgLen - p) < rec.idLen) return false;
-		rec.id = p;
-		p += rec.idLen;
-	}
-	else {
-		rec.id = nullptr;
-	}
+        if (rec.idLen)
+        {
+                if ((size_t)(msg + msgLen - p) < rec.idLen)
+                        return false;
+                rec.id = p;
+                p += rec.idLen;
+        }
+        else
+        {
+                rec.id = nullptr;
+        }
 
-	if ((size_t)(msg + msgLen - p) < rec.payloadLen) return false;
-	rec.payload = p;
-	return true;
+        if ((size_t)(msg + msgLen - p) < rec.payloadLen)
+                return false;
+        rec.payload = p;
+        return true;
 }
 
-bool NdefHelper::isTextRecord(const NdefRecord& rec) const {
-	return rec.tnf == 0x01 &&
-		rec.typeLen == 1 &&
-		rec.type != nullptr &&
-		rec.type[0] == 'T';
+bool NdefHelper::isTextRecord(const NdefRecord& rec) const
+{
+        return rec.tnf == 0x01 &&
+               rec.typeLen == 1 &&
+               rec.type != nullptr &&
+               rec.type[0] == 'T';
 }
 
-void NdefHelper::decodeAndPrintTextRecord(const NdefRecord& r) const {
-	if (!isTextRecord(r)) {
-		return;
-	}
-	if (r.payloadLen < 1) {
-		Serial.println(F("Empty RTD/T payload"));
-		return;
-	}
+void NdefHelper::decodeAndPrintTextRecord(const NdefRecord& r) const
+{
+        if (!isTextRecord(r))
+        {
+                return;
+        }
+        if (r.payloadLen < 1)
+        {
+                Serial.println(F("Empty RTD/T payload"));
+                return;
+        }
 
-	uint8_t status = r.payload[0];
-	bool utf16 = (status & 0x80) != 0;
-	uint8_t langLen = (status & 0x3F);
-	if (r.payloadLen < (size_t)(1 + langLen)) {
-		Serial.println(F("RTD/T payload too short"));
-		return;
-	}
+        uint8_t status = r.payload[0];
+        bool utf16 = (status & 0x80) != 0;
+        uint8_t langLen = (status & 0x3F);
+        if (r.payloadLen < (size_t)(1 + langLen))
+        {
+                Serial.println(F("RTD/T payload too short"));
+                return;
+        }
 
-	String lang;
-	for (uint8_t i = 0; i < langLen; ++i) {
-		lang += (char)r.payload[1 + i];
-	}
-	const uint8_t* textPtr = r.payload + 1 + langLen;
-	size_t textLen = r.payloadLen - 1 - langLen;
+        String lang;
+        for (uint8_t i = 0; i < langLen; ++i)
+        {
+                lang += (char)r.payload[1 + i];
+        }
+        const uint8_t* textPtr = r.payload + 1 + langLen;
+        size_t textLen = r.payloadLen - 1 - langLen;
 
-	Serial.print(F("NDEF Text: ("));
-	Serial.print(utf16 ? F("UTF-16") : F("UTF-8"));
-	Serial.print(F(", "));
-	Serial.print(lang);
-	Serial.println(F(")"));
-	Serial.println(F("Text payload:"));
-	if (utf16) {
-		dumpHexAscii(textPtr, textLen);
-	}
-	else {
-		for (size_t i = 0; i < textLen; ++i) {
-			char c = (char)textPtr[i];
-			Serial.print(isprint((unsigned char)c) ? c : '.');
-		}
-		Serial.println();
-	}
+        Serial.print(F("NDEF Text: ("));
+        Serial.print(utf16 ? F("UTF-16") : F("UTF-8"));
+        Serial.print(F(", "));
+        Serial.print(lang);
+        Serial.println(F(")"));
+        Serial.println(F("Text payload:"));
+        if (utf16)
+        {
+                dumpHexAscii(textPtr, textLen);
+        }
+        else
+        {
+                for (size_t i = 0; i < textLen; ++i)
+                {
+                        char c = (char)textPtr[i];
+                        Serial.print(isprint((unsigned char)c) ? c : '.');
+                }
+                Serial.println();
+        }
 }
 
-void NdefHelper::dumpHexAscii(const uint8_t* data, size_t len) const {
-	Serial.print(F("Data ("));
-	Serial.print(len);
-	Serial.println(F(" bytes):"));
-	for (size_t i = 0; i < len; i += 16) {
-		Serial.printf("%04u: ", (unsigned)i);
-		for (size_t j = 0; j < 16; ++j) {
-			if (i + j < len) {
-				Serial.printf("%02X ", data[i + j]);
-			}
-			else {
-				Serial.print("   ");
-			}
-		}
-		Serial.print(" | ");
-		for (size_t j = 0; j < 16 && (i + j) < len; ++j) {
-			char c = (char)data[i + j];
-			Serial.print(isprint((unsigned char)c) ? c : '.');
-		}
-		Serial.println();
-	}
+void NdefHelper::dumpHexAscii(const uint8_t* data, size_t len) const
+{
+        Serial.print(F("Data ("));
+        Serial.print(len);
+        Serial.println(F(" bytes):"));
+        for (size_t i = 0; i < len; i += 16)
+        {
+                Serial.printf("%04u: ", (unsigned)i);
+                for (size_t j = 0; j < 16; ++j)
+                {
+                        if (i + j < len)
+                        {
+                                Serial.printf("%02X ", data[i + j]);
+                        }
+                        else
+                        {
+                                Serial.print("   ");
+                        }
+                }
+                Serial.print(" | ");
+                for (size_t j = 0; j < 16 && (i + j) < len; ++j)
+                {
+                        char c = (char)data[i + j];
+                        Serial.print(isprint((unsigned char)c) ? c : '.');
+                }
+                Serial.println();
+        }
 }

--- a/Src/Esp32NMCI/NdefHelper.h
+++ b/Src/Esp32NMCI/NdefHelper.h
@@ -4,35 +4,38 @@
 #include <stddef.h>
 #include <stdint.h>
 
-class NdefHelper {
+class NdefHelper
+{
 public:
-	struct Tlv {
-		uint8_t tag = 0;
-		const uint8_t* value = nullptr;
-		size_t length = 0;
-		const uint8_t* next = nullptr;
-	};
+        struct Tlv
+        {
+                uint8_t tag = 0;
+                const uint8_t* value = nullptr;
+                size_t length = 0;
+                const uint8_t* next = nullptr;
+        };
 
-	struct NdefRecord {
-		uint8_t tnf = 0;
-		bool mb = false;
-		bool me = false;
-		bool sr = false;
-		bool il = false;
-		uint8_t typeLen = 0;
-		uint32_t payloadLen = 0;
-		uint8_t idLen = 0;
-		const uint8_t* type = nullptr;
-		const uint8_t* id = nullptr;
-		const uint8_t* payload = nullptr;
-	};
+        struct NdefRecord
+        {
+                uint8_t tnf = 0;
+                bool mb = false;
+                bool me = false;
+                bool sr = false;
+                bool il = false;
+                uint8_t typeLen = 0;
+                uint32_t payloadLen = 0;
+                uint8_t idLen = 0;
+                const uint8_t* type = nullptr;
+                const uint8_t* id = nullptr;
+                const uint8_t* payload = nullptr;
+        };
 
-	bool findFirstNdefTlv(const uint8_t* data, size_t length, Tlv& out) const;
-	bool parseFirstRecord(const uint8_t* msg, size_t msgLen, NdefRecord& rec) const;
-	bool isTextRecord(const NdefRecord& rec) const;
-	void decodeAndPrintTextRecord(const NdefRecord& rec) const;
-	void dumpHexAscii(const uint8_t* data, size_t len) const;
+        bool findFirstNdefTlv(const uint8_t* data, size_t length, Tlv& out) const;
+        bool parseFirstRecord(const uint8_t* msg, size_t msgLen, NdefRecord& rec) const;
+        bool isTextRecord(const NdefRecord& rec) const;
+        void decodeAndPrintTextRecord(const NdefRecord& rec) const;
+        void dumpHexAscii(const uint8_t* data, size_t len) const;
 
 private:
-	bool parseNextTlv(const uint8_t* start, const uint8_t* end, Tlv& out) const;
+        bool parseNextTlv(const uint8_t* start, const uint8_t* end, Tlv& out) const;
 };

--- a/Src/Esp32NMCI/Type2TagReader.cpp
+++ b/Src/Esp32NMCI/Type2TagReader.cpp
@@ -3,53 +3,74 @@
 #include <string.h>
 
 Type2TagReader::Type2TagReader(PN532& nfc)
-	: nfc_(nfc) 
+    : nfc_(nfc)
 {
 }
 
-bool Type2TagReader::readCapabilityContainer(TagInfo& out) const {
-	uint8_t page3[4] = { 0 };
-	if (!nfc_.mifareultralight_ReadPage(3, page3)) {
-		return false;
-	}
+bool Type2TagReader::readCapabilityContainer(TagInfo& out) const
+{
+        uint8_t page3[4] = {0};
+        if (!nfc_.mifareultralight_ReadPage(3, page3))
+        {
+                return false;
+        }
 
-	out.ccMagic = page3[0];
-	out.verMaj = (page3[1] >> 4) & 0x0F;
-	out.verMin = page3[1] & 0x0F;
-	out.size8 = page3[2];
-	out.access = page3[3];
+        out.ccMagic = page3[0];
+        out.verMaj = (page3[1] >> 4) & 0x0F;
+        out.verMin = page3[1] & 0x0F;
+        out.size8 = page3[2];
+        out.access = page3[3];
 
-	out.ccValid = (out.ccMagic == 0xE1);
+        out.ccValid = (out.ccMagic == 0xE1);
 
-	out.userBytes = (uint16_t)out.size8 * 8u;
-	out.userPages = out.userBytes / kBytesPerPage;
+        out.userBytes = (uint16_t)out.size8 * 8u;
+        out.userPages = out.userBytes / kBytesPerPage;
 
-	switch (out.size8) {
-	case 0x06: out.probableType = "MIFARE Ultralight (48 B user)"; break;
-	case 0x0C: out.probableType = "MIFARE Ultralight C (96 B user)"; break;
-	case 0x12: out.probableType = "NTAG213 (144 B user)"; break;
-	case 0x3F: out.probableType = "NTAG215 (504 B user)"; break;
-	case 0x6F: out.probableType = "NTAG216 (888 B user)"; break;
-	default:   out.probableType = "Type 2 (unknown capacity)"; break;
-	}
+        switch (out.size8)
+        {
+        case 0x06:
+                out.probableType = "MIFARE Ultralight (48 B user)";
+                break;
+        case 0x0C:
+                out.probableType = "MIFARE Ultralight C (96 B user)";
+                break;
+        case 0x12:
+                out.probableType = "NTAG213 (144 B user)";
+                break;
+        case 0x3F:
+                out.probableType = "NTAG215 (504 B user)";
+                break;
+        case 0x6F:
+                out.probableType = "NTAG216 (888 B user)";
+                break;
+        default:
+                out.probableType = "Type 2 (unknown capacity)";
+                break;
+        }
 
-	return true;
+        return true;
 }
 
-bool Type2TagReader::readUserMemory(uint8_t* buffer, size_t bufferCap, const TagInfo& info) const {
-	if (!buffer || info.userBytes == 0) return false;
-	if (info.userBytes > bufferCap)     return false;
+bool Type2TagReader::readUserMemory(uint8_t* buffer, size_t bufferCap, const TagInfo& info) const
+{
+        if (!buffer || info.userBytes == 0)
+                return false;
+        if (info.userBytes > bufferCap)
+                return false;
 
-	for (uint16_t i = 0; i < info.userPages; ++i) {
-		if (!nfc_.mifareultralight_ReadPage(kFirstUserPage + i,
-			buffer + i * kBytesPerPage)) {
-			return false;
-		}
-	}
+        for (uint16_t i = 0; i < info.userPages; ++i)
+        {
+                if (!nfc_.mifareultralight_ReadPage(kFirstUserPage + i,
+                                                    buffer + i * kBytesPerPage))
+                {
+                        return false;
+                }
+        }
 
-	return true;
+        return true;
 }
 
-bool Type2TagReader::isSameUid(const uint8_t* lhs, const uint8_t* rhs, uint8_t len) {
-	return lhs && rhs && (memcmp(lhs, rhs, len) == 0);
+bool Type2TagReader::isSameUid(const uint8_t* lhs, const uint8_t* rhs, uint8_t len)
+{
+        return lhs && rhs && (memcmp(lhs, rhs, len) == 0);
 }

--- a/Src/Esp32NMCI/Type2TagReader.h
+++ b/Src/Esp32NMCI/Type2TagReader.h
@@ -4,29 +4,31 @@
 #include <stddef.h>
 #include <stdint.h>
 
-class Type2TagReader {
+class Type2TagReader
+{
 public:
-	struct TagInfo {
-		bool     ccValid = false;
-		uint8_t  ccMagic = 0x00;
-		uint8_t  verMaj = 0;
-		uint8_t  verMin = 0;
-		uint8_t  size8 = 0;
-		uint8_t  access = 0;
-		uint16_t userBytes = 0;
-		uint16_t userPages = 0;
-		const char* probableType = "Unknown Type 2";
-	};
+        struct TagInfo
+        {
+                bool ccValid = false;
+                uint8_t ccMagic = 0x00;
+                uint8_t verMaj = 0;
+                uint8_t verMin = 0;
+                uint8_t size8 = 0;
+                uint8_t access = 0;
+                uint16_t userBytes = 0;
+                uint16_t userPages = 0;
+                const char* probableType = "Unknown Type 2";
+        };
 
-	explicit Type2TagReader(PN532& nfc);
+        explicit Type2TagReader(PN532& nfc);
 
-	bool readCapabilityContainer(TagInfo& out) const;
-	bool readUserMemory(uint8_t* buffer, size_t bufferCap, const TagInfo& info) const;
-	static bool isSameUid(const uint8_t* lhs, const uint8_t* rhs, uint8_t len);
+        bool readCapabilityContainer(TagInfo& out) const;
+        bool readUserMemory(uint8_t* buffer, size_t bufferCap, const TagInfo& info) const;
+        static bool isSameUid(const uint8_t* lhs, const uint8_t* rhs, uint8_t len);
 
 private:
-	static constexpr uint8_t kBytesPerPage = 4;
-	static constexpr uint8_t kFirstUserPage = 4;
+        static constexpr uint8_t kBytesPerPage = 4;
+        static constexpr uint8_t kFirstUserPage = 4;
 
-	PN532& nfc_;
+        PN532& nfc_;
 };


### PR DESCRIPTION
## Summary
- reformat the ESP32 NMCI sketch to use Allman-style braces and indentation
- apply the same Allman formatting to the Type2TagReader and NdefHelper sources and headers

## Testing
- not run (format-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf92aec47c8323a102ed5444b26419