### PR TITLE
Extract PN532 configuration to header

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -18,20 +18,13 @@
 #include <PN532_HSU.h>
 #include <string.h>
 
+#include "config.h"
 #include "NdefHelper.h"
 #include "Type2TagReader.h"
-
-#define PN532_HSU_PORT Serial2
-static const uint32_t PN532_HSU_BAUDRATE = 115200;
-static const int PN532_HSU_RX_PIN = 26; // ESP32 RX  (an PN532 TX)
-static const int PN532_HSU_TX_PIN = 25; // ESP32 TX  (an PN532 RX)
 
 static PN532_HSU pn532hsu(PN532_HSU_PORT);
 static PN532 nfc(pn532hsu);
 static Type2TagReader tagReader(nfc);
-
-constexpr uint8_t kUidBufferMax = 10;    // 4/7/10 Byte UIDs
-constexpr uint16_t kUserMaxBytes = 1024; // reicht für NTAG216 (888 B)
 
 static NdefHelper ndefHelper;
 

--- a/Src/Esp32NMCI/config.h
+++ b/Src/Esp32NMCI/config.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stdint.h>
+
+// Serial port used to communicate with the PN532 module over High Speed UART.
+#define PN532_HSU_PORT Serial2
+
+// Baud rate for the PN532 HSU serial connection.
+constexpr uint32_t PN532_HSU_BAUDRATE = 115200;
+
+// ESP32 pin receiving data from the PN532 (connect to PN532 TX).
+constexpr int PN532_HSU_RX_PIN = 26;
+
+// ESP32 pin transmitting data to the PN532 (connect to PN532 RX).
+constexpr int PN532_HSU_TX_PIN = 25;
+
+// Maximum UID length supported (Type 2 tags are 4, 7, or 10 bytes).
+constexpr uint8_t kUidBufferMax = 10;
+
+// Maximum number of user memory bytes to read from a tag (covers NTAG216).
+constexpr uint16_t kUserMaxBytes = 1024;


### PR DESCRIPTION
## Summary
- add a dedicated `config.h` with PN532 communication constants and descriptive comments
- include the new header from `Esp32NMCI.ino` and remove the inlined constant definitions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf9462179483238334e1be5f5301e7