### PR TITLE
Fix Logger base handling for non-numeric values

### DIFF
--- a/Src/Esp32NMCI/src/Logger/Logger.h
+++ b/Src/Esp32NMCI/src/Logger/Logger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <type_traits>
 
 class Logger
 {
@@ -12,30 +13,25 @@ class Logger
     static void log();
 
     template <typename T>
-    static void log(const T &value, bool newline = true, int base = kNoBase)
+    static typename std::enable_if<std::is_arithmetic<typename std::decay<T>::type>::value>::type log(
+        const T &value, bool newline = true, int base = kNoBase)
     {
         if (base == kNoBase)
         {
-            if (newline)
-            {
-                Serial.println(value);
-            }
-            else
-            {
-                Serial.print(value);
-            }
+            printValue(value, newline);
         }
         else
         {
-            if (newline)
-            {
-                Serial.println(value, base);
-            }
-            else
-            {
-                Serial.print(value, base);
-            }
+            printValue(value, newline, base);
         }
+    }
+
+    template <typename T>
+    static typename std::enable_if<!std::is_arithmetic<typename std::decay<T>::type>::value>::type log(
+        const T &value, bool newline = true, int base = kNoBase)
+    {
+        (void)base;
+        printValue(value, newline);
     }
 
     template <typename... Args>
@@ -45,4 +41,31 @@ class Logger
     }
 
     static void flush();
+
+private:
+    template <typename T>
+    static void printValue(const T &value, bool newline)
+    {
+        if (newline)
+        {
+            Serial.println(value);
+        }
+        else
+        {
+            Serial.print(value);
+        }
+    }
+
+    template <typename T>
+    static void printValue(const T &value, bool newline, int base)
+    {
+        if (newline)
+        {
+            Serial.println(value, base);
+        }
+        else
+        {
+            Serial.print(value, base);
+        }
+    }
 };


### PR DESCRIPTION
## Summary
- guard Logger's templated log helper so base formatting is only used with arithmetic types
- fall back to standard Serial printing for strings and Flash strings to avoid invalid overloads

## Testing
- not run (environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfac45633083239968732741dab96f