### PR TITLE
Replace Logger::log calls with Logger::LogInfo

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -43,24 +43,24 @@ void setup()
     uint32_t versiondata = nfc.getFirmwareVersion();
     if (!versiondata)
     {
-        Logger::log(F("PN532 not found (check wiring & HSU mode)"));
+        Logger::LogInfo(F("PN532 not found (check wiring & HSU mode)"));
         while (true)
         {
             delay(1000); // Endless Loop Stop TODO: Write ERROR TO THE T-DISPLAY
         }
     }
 
-    Logger::log(F("Found chip PN5"), false);
-    Logger::log((versiondata >> 24) & 0xFF, true, HEX);
-    Logger::log(F("Firmware ver. "), false);
-    Logger::log((versiondata >> 16) & 0xFF, false, DEC);
-    Logger::log('.', false);
-    Logger::log((versiondata >> 8) & 0xFF, true, DEC);
+    Logger::LogInfo(F("Found chip PN5"), false);
+    Logger::LogInfo((versiondata >> 24) & 0xFF, true, HEX);
+    Logger::LogInfo(F("Firmware ver. "), false);
+    Logger::LogInfo((versiondata >> 16) & 0xFF, false, DEC);
+    Logger::LogInfo('.', false);
+    Logger::LogInfo((versiondata >> 8) & 0xFF, true, DEC);
 
     nfc.SAMConfig();
     nfc.setPassiveActivationRetries(0xFF);
 
-    Logger::log(F("Waiting for an ISO14443A Card ..."));
+    Logger::LogInfo(F("Waiting for an ISO14443A Card ..."));
 }
 
 void loop()
@@ -84,47 +84,47 @@ void loop()
             lastUidLength = uidLength;
             memcpy(lastUid, uid, uidLength);
 
-            Logger::log(F("Tag detected. UID length: "), false);
-            Logger::log(uidLength);
-            Logger::log(F("UID: "), false);
+            Logger::LogInfo(F("Tag detected. UID length: "), false);
+            Logger::LogInfo(uidLength);
+            Logger::LogInfo(F("UID: "), false);
             nfc.PrintHex(uid, uidLength);
 
             // --- 1) CC lesen & interpretieren ---
             Type2TagReader::TagInfo ti{};
             if (!tagReader.readCapabilityContainer(ti))
             {
-                Logger::log(F("Failed to read Capability Container (page 3)"));
+                Logger::LogInfo(F("Failed to read Capability Container (page 3)"));
                 return;
             }
 
-            Logger::log(F("CC: Magic=0x"), false);
-            Logger::log(ti.ccMagic, false, HEX);
-            Logger::log(F(", Ver="), false);
-            Logger::log(ti.verMaj, false);
-            Logger::log('.', false);
-            Logger::log(ti.verMin, false);
-            Logger::log(F(", Size8=0x"), false);
-            Logger::log(ti.size8, false, HEX);
-            Logger::log(F(" ("), false);
-            Logger::log(ti.userBytes, false);
-            Logger::log(F(" bytes user)"), false);
-            Logger::log(F(", Access=0x"), false);
-            Logger::log(ti.access, false, HEX);
-            Logger::log();
+            Logger::LogInfo(F("CC: Magic=0x"), false);
+            Logger::LogInfo(ti.ccMagic, false, HEX);
+            Logger::LogInfo(F(", Ver="), false);
+            Logger::LogInfo(ti.verMaj, false);
+            Logger::LogInfo('.', false);
+            Logger::LogInfo(ti.verMin, false);
+            Logger::LogInfo(F(", Size8=0x"), false);
+            Logger::LogInfo(ti.size8, false, HEX);
+            Logger::LogInfo(F(" ("), false);
+            Logger::LogInfo(ti.userBytes, false);
+            Logger::LogInfo(F(" bytes user)"), false);
+            Logger::LogInfo(F(", Access=0x"), false);
+            Logger::LogInfo(ti.access, false, HEX);
+            Logger::LogInfo();
 
             if (!ti.ccValid)
             {
-                Logger::log(F("Warning: CC Magic != 0xE1 (evtl. kein NDEF-Tag oder CC korrupt)"));
+                Logger::LogInfo(F("Warning: CC Magic != 0xE1 (evtl. kein NDEF-Tag oder CC korrupt)"));
             }
 
-            Logger::log(F("Probable type: "));
-            Logger::log(ti.probableType);
+            Logger::LogInfo(F("Probable type: "));
+            Logger::LogInfo(ti.probableType);
 
             // --- 2) User Memory vollständig lesen (dynamisch) ---
             static uint8_t user[kUserMaxBytes];
             if (!tagReader.readUserMemory(user, sizeof(user), ti))
             {
-                Logger::log(F("Failed to read user memory"));
+                Logger::LogInfo(F("Failed to read user memory"));
                 return;
             }
 
@@ -137,8 +137,8 @@ void loop()
 
             if (foundNdef)
             {
-                Logger::log(F("NDEF length (TLV): "), false);
-                Logger::log(static_cast<unsigned>(tlv.length));
+                Logger::LogInfo(F("NDEF length (TLV): "), false);
+                Logger::LogInfo(static_cast<unsigned>(tlv.length));
 
                 // --- 4) Ersten NDEF-Record parsen & bei Text ausgeben ---
                 NdefHelper::NdefRecord rec{};
@@ -151,19 +151,19 @@ void loop()
                     }
                     else
                     {
-                        Logger::log(F("First NDEF record is not a Text (RTD/T) record."));
-                        Logger::log(F("Record header / payload (hex):"));
+                        Logger::LogInfo(F("First NDEF record is not a Text (RTD/T) record."));
+                        Logger::LogInfo(F("Record header / payload (hex):"));
                         ndefHelper.dumpHexAscii(tlv.value, tlv.length);
                     }
                 }
                 else
                 {
-                    Logger::log(F("Failed to parse first NDEF record"));
+                    Logger::LogInfo(F("Failed to parse first NDEF record"));
                 }
             }
             else
             {
-                Logger::log(F("No NDEF TLV found (0x03)"));
+                Logger::LogInfo(F("No NDEF TLV found (0x03)"));
             }
         }
     }
@@ -172,7 +172,7 @@ void loop()
         tagPresent = false;
         lastUidLength = 0;
         memset(lastUid, 0, sizeof(lastUid));
-        Logger::log(F("Tag removed"));
+        Logger::LogInfo(F("Tag removed"));
     }
 
     delay(250);

--- a/Src/Esp32NMCI/src/CardReader/NdefHelper.cpp
+++ b/Src/Esp32NMCI/src/CardReader/NdefHelper.cpp
@@ -163,7 +163,7 @@ void NdefHelper::decodeAndPrintTextRecord(const NdefRecord &r) const
     }
     if (r.payloadLen < 1)
     {
-        Logger::log(F("Empty RTD/T payload"));
+        Logger::LogInfo(F("Empty RTD/T payload"));
         return;
     }
 
@@ -172,7 +172,7 @@ void NdefHelper::decodeAndPrintTextRecord(const NdefRecord &r) const
     uint8_t langLen = (status & 0x3F);
     if (r.payloadLen < (size_t)(1 + langLen))
     {
-        Logger::log(F("RTD/T payload too short"));
+        Logger::LogInfo(F("RTD/T payload too short"));
         return;
     }
 
@@ -184,12 +184,12 @@ void NdefHelper::decodeAndPrintTextRecord(const NdefRecord &r) const
     const uint8_t *textPtr = r.payload + 1 + langLen;
     size_t textLen = r.payloadLen - 1 - langLen;
 
-    Logger::log(F("NDEF Text: ("), false);
-    Logger::log(utf16 ? F("UTF-16") : F("UTF-8"), false);
-    Logger::log(F(", "), false);
-    Logger::log(lang, false);
-    Logger::log(F(")"));
-    Logger::log(F("Text payload:"));
+    Logger::LogInfo(F("NDEF Text: ("), false);
+    Logger::LogInfo(utf16 ? F("UTF-16") : F("UTF-8"), false);
+    Logger::LogInfo(F(", "), false);
+    Logger::LogInfo(lang, false);
+    Logger::LogInfo(F(")"));
+    Logger::LogInfo(F("Text payload:"));
     if (utf16)
     {
         dumpHexAscii(textPtr, textLen);
@@ -199,17 +199,17 @@ void NdefHelper::decodeAndPrintTextRecord(const NdefRecord &r) const
         for (size_t i = 0; i < textLen; ++i)
         {
             char c = (char)textPtr[i];
-            Logger::log(isprint((unsigned char)c) ? c : '.', false);
+            Logger::LogInfo(isprint((unsigned char)c) ? c : '.', false);
         }
-        Logger::log();
+        Logger::LogInfo();
     }
 }
 
 void NdefHelper::dumpHexAscii(const uint8_t *data, size_t len) const
 {
-    Logger::log(F("Data ("), false);
-    Logger::log(len, false);
-    Logger::log(F(" bytes):"));
+    Logger::LogInfo(F("Data ("), false);
+    Logger::LogInfo(len, false);
+    Logger::LogInfo(F(" bytes):"));
     for (size_t i = 0; i < len; i += 16)
     {
         Logger::logf("%04u: ", (unsigned)i);
@@ -221,15 +221,15 @@ void NdefHelper::dumpHexAscii(const uint8_t *data, size_t len) const
             }
             else
             {
-                Logger::log("   ", false);
+                Logger::LogInfo("   ", false);
             }
         }
-        Logger::log(" | ", false);
+        Logger::LogInfo(" | ", false);
         for (size_t j = 0; j < 16 && (i + j) < len; ++j)
         {
             char c = (char)data[i + j];
-            Logger::log(isprint((unsigned char)c) ? c : '.', false);
+            Logger::LogInfo(isprint((unsigned char)c) ? c : '.', false);
         }
-        Logger::log();
+        Logger::LogInfo();
     }
 }

--- a/Src/Esp32NMCI/src/Logger/Logger.cpp
+++ b/Src/Esp32NMCI/src/Logger/Logger.cpp
@@ -23,6 +23,11 @@ void Logger::log()
     s_atLineStart = true;
 }
 
+void Logger::LogInfo()
+{
+    log();
+}
+
 void Logger::flush()
 {
     Serial.flush();

--- a/Src/Esp32NMCI/src/Logger/Logger.h
+++ b/Src/Esp32NMCI/src/Logger/Logger.h
@@ -43,6 +43,11 @@ public:
     static void log();
 
     /**
+     * @brief Convenience wrapper for emitting an empty informational log line.
+     */
+    static void LogInfo();
+
+    /**
      * @brief Logs arithmetic values with optional base, newline handling and severity level.
      *
      * Example:
@@ -80,6 +85,12 @@ public:
     {
         (void)base;
         printValue(value, newline, level);
+    }
+
+    template <typename T>
+    static void LogInfo(const T &value, bool newline = true, int base = kNoBase)
+    {
+        log(value, newline, base, Level::Info);
     }
 
     /**

--- a/Src/Esp32NMCI/src/Presentation/ButtonManager.cpp
+++ b/Src/Esp32NMCI/src/Presentation/ButtonManager.cpp
@@ -20,7 +20,7 @@ void ButtonManager::update()
     stateA = digitalRead(pinA) == LOW;
     if (stateA && !lastStateA && onButton0Pressed)
     {
-        Logger::log(F("[ButtonManager] Button 0 pressed"));
+        Logger::LogInfo(F("[ButtonManager] Button 0 pressed"));
         onButton0Pressed();
     }
 
@@ -37,7 +37,7 @@ void ButtonManager::update()
         unsigned long duration = millis() - pressStart35;
         if (duration < longPressThreshold && onButton35Pressed)
         {
-            Logger::log(F("[ButtonManager] Button 35 short press"));
+            Logger::LogInfo(F("[ButtonManager] Button 35 short press"));
             onButton35Pressed();
         }
     }


### PR DESCRIPTION
## Summary
- add Logger::LogInfo wrappers so the new call name maps to the existing info-level logging behavior
- update ESP32 firmware sources to invoke Logger::LogInfo instead of Logger::log for informational output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfc59decf08323bd7a00b3c3db5dec