### PR TITLE
Add log level filtering to Logger

### DIFF
--- a/Src/Esp32NMCI/src/Logger/Logger.cpp
+++ b/Src/Esp32NMCI/src/Logger/Logger.cpp
@@ -3,8 +3,9 @@
 #include <cstring>
 
 bool Logger::s_atLineStart = true;
+Logger::Level Logger::s_filterLevel = Logger::Level::Debug;
 
-void Logger::begin(unsigned long baudRate, bool waitForSerial)
+void Logger::begin(unsigned long baudRate, bool waitForSerial, Level filterLevel)
 {
     Serial.begin(baudRate);
     if (waitForSerial)
@@ -14,11 +15,16 @@ void Logger::begin(unsigned long baudRate, bool waitForSerial)
             delay(100);
         }
     }
+    s_filterLevel = filterLevel;
     s_atLineStart = true;
 }
 
 void Logger::log()
 {
+    if (!isLevelEnabled(Level::Info))
+    {
+        return;
+    }
     Serial.println();
     s_atLineStart = true;
 }
@@ -63,4 +69,25 @@ bool Logger::formatEndsWithNewline(const char *format)
 
     const char *lastNewline = std::strrchr(format, '\n');
     return lastNewline != nullptr && lastNewline[1] == '\0';
+}
+
+bool Logger::isLevelEnabled(Level level)
+{
+    return levelPriority(level) >= levelPriority(s_filterLevel);
+}
+
+uint8_t Logger::levelPriority(Level level)
+{
+    switch (level)
+    {
+    case Level::Error:
+        return 4;
+    case Level::Warn:
+        return 3;
+    case Level::Info:
+        return 2;
+    case Level::Debug:
+    default:
+        return 1;
+    }
 }

--- a/Src/Esp32NMCI/src/Logger/Logger.h
+++ b/Src/Esp32NMCI/src/Logger/Logger.h
@@ -29,8 +29,11 @@ public:
      *
      * @param baudRate Desired baud rate for the serial port.
      * @param waitForSerial When true, blocks until the serial port becomes available.
+     * @param filterLevel Minimum severity level that will be emitted. Defaults to
+     *        Logger::Level::Debug to allow full output.
      */
-    static void begin(unsigned long baudRate = 115200, bool waitForSerial = true);
+    static void begin(unsigned long baudRate = 115200, bool waitForSerial = true,
+                      Level filterLevel = Level::Debug);
 
     /**
      * @brief Emits an empty log line, separating two messages.
@@ -60,6 +63,10 @@ public:
     static typename std::enable_if<std::is_arithmetic<typename std::decay<T>::type>::value>::type log(
         const T &value, bool newline = true, int base = kNoBase, Level level = Level::Info)
     {
+        if (!isLevelEnabled(level))
+        {
+            return;
+        }
         if (base == kNoBase)
         {
             printValue(value, newline, level);
@@ -84,6 +91,10 @@ public:
         const T &value, bool newline = true, int base = kNoBase, Level level = Level::Info)
     {
         (void)base;
+        if (!isLevelEnabled(level))
+        {
+            return;
+        }
         printValue(value, newline, level);
     }
 
@@ -161,6 +172,10 @@ public:
     template <typename... Args>
     static void logf(Level level, const char *format, Args... args)
     {
+        if (!isLevelEnabled(level))
+        {
+            return;
+        }
         if (s_atLineStart)
         {
             printPrefix(level);
@@ -236,6 +251,9 @@ private:
 
     static void printPrefix(Level level);
     static bool formatEndsWithNewline(const char *format);
+    static bool isLevelEnabled(Level level);
+    static uint8_t levelPriority(Level level);
 
     static bool s_atLineStart;
+    static Level s_filterLevel;
 };


### PR DESCRIPTION
## Summary
- add a configurable log level filter parameter to `Logger::begin`
- suppress log output below the configured severity across log helpers

## Testing
- not run (Arduino build environment unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68cfc75402548323bcfba5d624f495d2