### PR TITLE
Add log level helpers and configure info filter

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -33,7 +33,7 @@ static NdefHelper ndefHelper;
 
 void setup()
 {
-    Logger::begin(115200, true );
+    Logger::begin(115200, true, Logger::Level::Info);
 
     // Setup Card Reader
 

--- a/Src/Esp32NMCI/src/Logger/Logger.cpp
+++ b/Src/Esp32NMCI/src/Logger/Logger.cpp
@@ -71,6 +71,26 @@ bool Logger::formatEndsWithNewline(const char *format)
     return lastNewline != nullptr && lastNewline[1] == '\0';
 }
 
+bool Logger::isLogLevel(Level level)
+{
+    return isLevelEnabled(level);
+}
+
+bool Logger::isLogLevelInfo()
+{
+    return isLogLevel(Level::Info);
+}
+
+bool Logger::isLogLevelWarn()
+{
+    return isLogLevel(Level::Warn);
+}
+
+bool Logger::isLogLevelDebug()
+{
+    return isLogLevel(Level::Debug);
+}
+
 bool Logger::isLevelEnabled(Level level)
 {
     return levelPriority(level) >= levelPriority(s_filterLevel);

--- a/Src/Esp32NMCI/src/Logger/Logger.h
+++ b/Src/Esp32NMCI/src/Logger/Logger.h
@@ -208,6 +208,26 @@ public:
      */
     static void flush();
 
+    /**
+     * @brief Checks whether logging is enabled for a specific level.
+     */
+    static bool isLogLevel(Level level);
+
+    /**
+     * @brief Checks whether info level logging is enabled.
+     */
+    static bool isLogLevelInfo();
+
+    /**
+     * @brief Checks whether warning level logging is enabled.
+     */
+    static bool isLogLevelWarn();
+
+    /**
+     * @brief Checks whether debug level logging is enabled.
+     */
+    static bool isLogLevelDebug();
+
 private:
     template <typename T>
     static void printValue(const T &value, bool newline, Level level)


### PR DESCRIPTION
## Summary
- add helper methods for querying active log levels in the logger
- initialize the logger in setup with an info-level filter to reduce output

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfcc54ae948323a256c998aa55b393