### PR TITLE
Refactor PN532 handling into CardReaderManager

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -16,9 +16,9 @@
 
 #include <PN532.h>
 #include <PN532_HSU.h>
-#include <string.h>
 
 #include "config.h"
+#include "src/CardReader/CardReaderManager.h"
 #include "src/CardReader/NdefHelper.h"
 #include "src/CardReader/Type2TagReader.h"
 #include "src/Logger/Logger.h"
@@ -30,150 +30,41 @@ static PN532 nfc(pn532hsu);
 static Type2TagReader tagReader(nfc);
 
 static NdefHelper ndefHelper;
+static CardReaderManager cardReaderManager(nfc, tagReader, ndefHelper);
+
+static void OnPayloadRead(const NdefHelper::NdefRecord &record);
 
 void setup()
 {
     Logger::begin(115200, true, Logger::Level::Info);
-
-    // Setup Card Reader
-
-    PN532_HSU_PORT.begin(PN532_HSU_BAUDRATE, SERIAL_8N1, PN532_HSU_RX_PIN, PN532_HSU_TX_PIN);
-    nfc.begin();
-
-    uint32_t versiondata = nfc.getFirmwareVersion();
-    if (!versiondata)
-    {
-        Logger::LogInfo(F("PN532 not found (check wiring & HSU mode)"));
-        while (true)
-        {
-            delay(1000); // Endless Loop Stop TODO: Write ERROR TO THE T-DISPLAY
-        }
-    }
-
-    Logger::LogInfo(F("Found chip PN5"), false);
-    Logger::LogInfo((versiondata >> 24) & 0xFF, true, HEX);
-    Logger::LogInfo(F("Firmware ver. "), false);
-    Logger::LogInfo((versiondata >> 16) & 0xFF, false, DEC);
-    Logger::LogInfo('.', false);
-    Logger::LogInfo((versiondata >> 8) & 0xFF, true, DEC);
-
-    nfc.SAMConfig();
-    nfc.setPassiveActivationRetries(0xFF);
-
-    Logger::LogInfo("Initialized");
-    Logger::LogDebug(F("Waiting for an ISO14443A Card ..."));
+    cardReaderManager.setPayloadCallback(OnPayloadRead);
+    cardReaderManager.begin();
 }
 
 void loop()
 {
-    static uint8_t lastUid[kUidBufferMax] = {0};
-    static uint8_t lastUidLength = 0;
-    static bool tagPresent = false;
+    cardReaderManager.process();
+}
 
-    uint8_t uid[kUidBufferMax] = {0};
-    uint8_t uidLength = 0;
+static void OnPayloadRead(const NdefHelper::NdefRecord &record)
+{
+    Logger::LogInfo(F("OnPayloadRead - payload length: "), false);
+    Logger::LogInfo(static_cast<unsigned long>(record.payloadLen));
 
-    if (nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength))
+    if (!record.payload || record.payloadLen == 0)
     {
-        bool newTagDetected = (!tagPresent) ||
-                              (uidLength != lastUidLength) ||
-                              (!Type2TagReader::isSameUid(uid, lastUid, uidLength));
-
-        if (newTagDetected)
-        {
-            tagPresent = true;
-            lastUidLength = uidLength;
-            memcpy(lastUid, uid, uidLength);
-
-            Logger::LogDebug(F("Tag detected. UID length: "), false);
-            Logger::LogDebug(uidLength);
-            Logger::LogDebug(F("UID: "), false);
-            nfc.PrintHex(uid, uidLength);
-
-            // --- 1) CC lesen & interpretieren ---
-            Type2TagReader::TagInfo ti{};
-            if (!tagReader.readCapabilityContainer(ti))
-            {
-                Logger::LogWarn(F("Failed to read Capability Container (page 3)"));
-                return;
-            }
-
-            Logger::LogDebug(F("CC: Magic=0x"), false);
-            Logger::LogDebug(ti.ccMagic, false, HEX);
-            Logger::LogDebug(F(", Ver="), false);
-            Logger::LogDebug(ti.verMaj, false);
-            Logger::LogDebug('.', false);
-            Logger::LogDebug(ti.verMin, false);
-            Logger::LogDebug(F(", Size8=0x"), false);
-            Logger::LogDebug(ti.size8, false, HEX);
-            Logger::LogDebug(F(" ("), false);
-            Logger::LogDebug(ti.userBytes, false);
-            Logger::LogDebug(F(" bytes user)"), false);
-            Logger::LogDebug(F(", Access=0x"), false);
-            Logger::LogDebug(ti.access, false, HEX);
-
-            if (!ti.ccValid)
-            {
-                Logger::LogWarn(F("Warning: CC Magic != 0xE1 (evtl. kein NDEF-Tag oder CC korrupt)"));
-            }
-
-            Logger::LogDebug(F("Probable type: "));
-            Logger::LogDebug(ti.probableType);
-
-            // --- 2) User Memory vollständig lesen (dynamisch) ---
-            static uint8_t user[kUserMaxBytes];
-            if (!tagReader.readUserMemory(user, sizeof(user), ti))
-            {
-                Logger::LogError(F("Failed to read user memory"));
-                return;
-            }
-
-            // Optional: Rohdump
-            // ndefHelper.dumpHexAscii(user, ti.userBytes);
-
-            // --- 3) TLV scannen: NDEF (0x03) finden ---
-            NdefHelper::Tlv tlv{};
-            bool foundNdef = ndefHelper.findFirstNdefTlv(user, ti.userBytes, tlv);
-
-            if (foundNdef)
-            {
-                Logger::LogDebug(F("NDEF length (TLV): "), false);
-                Logger::LogDebug(static_cast<unsigned>(tlv.length));
-
-                // --- 4) Ersten NDEF-Record parsen & bei Text ausgeben ---
-                NdefHelper::NdefRecord rec{};
-                if (ndefHelper.parseFirstRecord(tlv.value, tlv.length, rec))
-                {
-                    // Wenn es ein Text-Record ist, gib den Text direkt aus (wie bei dir genutzt)
-                    if (ndefHelper.isTextRecord(rec))
-                    {
-                        ndefHelper.decodeAndPrintTextRecord(rec);
-                    }
-                    else
-                    {
-                        Logger::LogWarn(F("First NDEF record is not a Text (RTD/T) record."));
-                        Logger::LogWarn(F("Record header / payload (hex):"));
-                        ndefHelper.dumpHexAscii(tlv.value, tlv.length);
-                    }
-                }
-                else
-                {
-                    Logger::LogWarn(F("Failed to parse first NDEF record"));
-                }
-            }
-            else
-            {
-                Logger::LogWarn(F("No NDEF TLV found (0x03)"));
-            }
-        }
-    }
-    else if (tagPresent)
-    {
-        tagPresent = false;
-        lastUidLength = 0;
-        memset(lastUid, 0, sizeof(lastUid));
-        Logger::LogDebug(F("Tag removed"));
+        Logger::LogWarn(F("Received record with empty payload."));
+        return;
     }
 
-    delay(250);
+    if (ndefHelper.isTextRecord(record))
+    {
+        ndefHelper.decodeAndPrintTextRecord(record);
+    }
+    else
+    {
+        Logger::LogWarn(F("First NDEF record is not a Text (RTD/T) record."));
+        Logger::LogInfo(F("Payload (hex):"));
+        ndefHelper.dumpHexAscii(record.payload, record.payloadLen);
+    }
 }

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
@@ -1,0 +1,154 @@
+#include "CardReaderManager.h"
+
+#include <Arduino.h>
+#include <string.h>
+
+#include "../Logger/Logger.h"
+
+CardReaderManager::CardReaderManager(PN532 &nfc, Type2TagReader &tagReader, NdefHelper &ndefHelper)
+    : nfc_(nfc), tagReader_(tagReader), ndefHelper_(ndefHelper)
+{
+}
+
+void CardReaderManager::setPayloadCallback(PayloadCallback callback)
+{
+    payloadCallback_ = callback;
+}
+
+void CardReaderManager::begin()
+{
+    PN532_HSU_PORT.begin(PN532_HSU_BAUDRATE, SERIAL_8N1, PN532_HSU_RX_PIN, PN532_HSU_TX_PIN);
+    nfc_.begin();
+
+    uint32_t versiondata = nfc_.getFirmwareVersion();
+    if (!versiondata)
+    {
+        Logger::LogInfo(F("PN532 not found (check wiring & HSU mode)"));
+        while (true)
+        {
+            delay(1000);
+        }
+    }
+
+    Logger::LogInfo(F("Found chip PN5"), false);
+    Logger::LogInfo((versiondata >> 24) & 0xFF, true, HEX);
+    Logger::LogInfo(F("Firmware ver. "), false);
+    Logger::LogInfo((versiondata >> 16) & 0xFF, false, DEC);
+    Logger::LogInfo('.', false);
+    Logger::LogInfo((versiondata >> 8) & 0xFF, true, DEC);
+
+    nfc_.SAMConfig();
+    nfc_.setPassiveActivationRetries(0xFF);
+
+    Logger::LogInfo(F("Initialized"));
+    Logger::LogDebug(F("Waiting for an ISO14443A Card ..."));
+}
+
+void CardReaderManager::process()
+{
+    uint8_t uid[kUidBufferMax] = {0};
+    uint8_t uidLength = 0;
+
+    if (nfc_.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength))
+    {
+        bool newTagDetected = (!tagPresent_) ||
+                              (uidLength != lastUidLength_) ||
+                              (!Type2TagReader::isSameUid(uid, lastUid_, uidLength));
+
+        if (newTagDetected)
+        {
+            tagPresent_ = true;
+            lastUidLength_ = uidLength;
+            memcpy(lastUid_, uid, uidLength);
+            handleTagDetected(uid, uidLength);
+        }
+    }
+    else if (tagPresent_)
+    {
+        handleTagRemoved();
+    }
+
+    delay(250);
+}
+
+void CardReaderManager::handleTagDetected(const uint8_t *uid, uint8_t uidLength)
+{
+    Logger::LogDebug(F("Tag detected. UID length: "), false);
+    Logger::LogDebug(uidLength);
+    Logger::LogDebug(F("UID: "), false);
+    nfc_.PrintHex(uid, uidLength);
+
+    Type2TagReader::TagInfo ti{};
+    if (!tagReader_.readCapabilityContainer(ti))
+    {
+        Logger::LogWarn(F("Failed to read Capability Container (page 3)"));
+        return;
+    }
+
+    Logger::LogDebug(F("CC: Magic=0x"), false);
+    Logger::LogDebug(ti.ccMagic, false, HEX);
+    Logger::LogDebug(F(", Ver="), false);
+    Logger::LogDebug(ti.verMaj, false);
+    Logger::LogDebug('.', false);
+    Logger::LogDebug(ti.verMin, false);
+    Logger::LogDebug(F(", Size8=0x"), false);
+    Logger::LogDebug(ti.size8, false, HEX);
+    Logger::LogDebug(F(" ("), false);
+    Logger::LogDebug(ti.userBytes, false);
+    Logger::LogDebug(F(" bytes user)"), false);
+    Logger::LogDebug(F(", Access=0x"), false);
+    Logger::LogDebug(ti.access, false, HEX);
+
+    if (!ti.ccValid)
+    {
+        Logger::LogWarn(F("Warning: CC Magic != 0xE1 (evtl. kein NDEF-Tag oder CC korrupt)"));
+    }
+
+    Logger::LogDebug(F("Probable type: "));
+    Logger::LogDebug(ti.probableType);
+
+    if (!tagReader_.readUserMemory(userMemory_, sizeof(userMemory_), ti))
+    {
+        Logger::LogError(F("Failed to read user memory"));
+        return;
+    }
+
+    NdefHelper::Tlv tlv{};
+    bool foundNdef = ndefHelper_.findFirstNdefTlv(userMemory_, ti.userBytes, tlv);
+
+    if (foundNdef)
+    {
+        Logger::LogDebug(F("NDEF length (TLV): "), false);
+        Logger::LogDebug(static_cast<unsigned>(tlv.length));
+
+        NdefHelper::NdefRecord rec{};
+        if (ndefHelper_.parseFirstRecord(tlv.value, tlv.length, rec))
+        {
+            notifyPayload(rec);
+        }
+        else
+        {
+            Logger::LogWarn(F("Failed to parse first NDEF record"));
+        }
+    }
+    else
+    {
+        Logger::LogWarn(F("No NDEF TLV found (0x03)"));
+    }
+}
+
+void CardReaderManager::handleTagRemoved()
+{
+    tagPresent_ = false;
+    lastUidLength_ = 0;
+    memset(lastUid_, 0, sizeof(lastUid_));
+    Logger::LogDebug(F("Tag removed"));
+}
+
+void CardReaderManager::notifyPayload(const NdefHelper::NdefRecord &record) const
+{
+    if (payloadCallback_)
+    {
+        payloadCallback_(record);
+    }
+}

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <PN532.h>
+#include <stdint.h>
+
+#include "../../../../config.h"
+#include "NdefHelper.h"
+#include "Type2TagReader.h"
+
+class CardReaderManager
+{
+    public:
+    using PayloadCallback = void (*)(const NdefHelper::NdefRecord &record);
+
+    CardReaderManager(PN532 &nfc, Type2TagReader &tagReader, NdefHelper &ndefHelper);
+
+    void begin();
+    void process();
+
+    void setPayloadCallback(PayloadCallback callback);
+
+    private:
+    void handleTagDetected(const uint8_t *uid, uint8_t uidLength);
+    void handleTagRemoved();
+    void notifyPayload(const NdefHelper::NdefRecord &record) const;
+
+    PN532 &nfc_;
+    Type2TagReader &tagReader_;
+    NdefHelper &ndefHelper_;
+    PayloadCallback payloadCallback_ = nullptr;
+
+    bool tagPresent_ = false;
+    uint8_t lastUid_[kUidBufferMax] = {0};
+    uint8_t lastUidLength_ = 0;
+    uint8_t userMemory_[kUserMaxBytes] = {0};
+};


### PR DESCRIPTION
## Summary
- add a CardReaderManager that encapsulates PN532 initialization, polling, and TLV parsing
- update the sketch to use the manager and expose an OnPayloadRead callback that logs the first record payload

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfceab0994832383ac0e4e0d3097b5