### PR TITLE
Fix config include paths for ESP32 build

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -17,7 +17,7 @@
 #include <PN532.h>
 #include <PN532_HSU.h>
 
-#include "config.h"
+#include "src/config.h"
 #include "src/CardReader/CardReaderManager.h"
 #include "src/CardReader/NdefHelper.h"
 #include "src/CardReader/Type2TagReader.h"

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
@@ -3,7 +3,7 @@
 #include <PN532.h>
 #include <stdint.h>
 
-#include "../../../../config.h"
+#include "../config.h"
 #include "NdefHelper.h"
 #include "Type2TagReader.h"
 

--- a/Src/Esp32NMCI/src/config.h
+++ b/Src/Esp32NMCI/src/config.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stdint.h>
+
+// Serial port used to communicate with the PN532 module over High Speed UART.
+#define PN532_HSU_PORT Serial2
+
+// Baud rate for the PN532 HSU serial connection.
+constexpr uint32_t PN532_HSU_BAUDRATE = 115200;
+
+// ESP32 pin receiving data from the PN532 (connect to PN532 TX).
+constexpr int PN532_HSU_RX_PIN = 26;
+
+// ESP32 pin transmitting data to the PN532 (connect to PN532 RX).
+constexpr int PN532_HSU_TX_PIN = 25;
+
+// Maximum UID length supported (Type 2 tags are 4, 7, or 10 bytes).
+constexpr uint8_t kUidBufferMax = 10;
+
+// Maximum number of user memory bytes to read from a tag (covers NTAG216).
+constexpr uint16_t kUserMaxBytes = 1024;

--- a/config.h
+++ b/config.h
@@ -1,21 +1,3 @@
 #pragma once
 
-#include <stdint.h>
-
-// Serial port used to communicate with the PN532 module over High Speed UART.
-#define PN532_HSU_PORT Serial2
-
-// Baud rate for the PN532 HSU serial connection.
-constexpr uint32_t PN532_HSU_BAUDRATE = 115200;
-
-// ESP32 pin receiving data from the PN532 (connect to PN532 TX).
-constexpr int PN532_HSU_RX_PIN = 26;
-
-// ESP32 pin transmitting data to the PN532 (connect to PN532 RX).
-constexpr int PN532_HSU_TX_PIN = 25;
-
-// Maximum UID length supported (Type 2 tags are 4, 7, or 10 bytes).
-constexpr uint8_t kUidBufferMax = 10;
-
-// Maximum number of user memory bytes to read from a tag (covers NTAG216).
-constexpr uint16_t kUserMaxBytes = 1024;
+#include "Src/Esp32NMCI/src/config.h"


### PR DESCRIPTION
## Summary
- move the shared configuration header into the sketch's src folder so Visual Micro copies it into the build tree
- update includes to reference the new location and keep a lightweight forwarder at the repository root for compatibility

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfd2dd0c188323a4cc3b09fd84212c