### PR TITLE
Refactor NDEF hex dump handling

### DIFF
--- a/Anarcho/SimpleRead_iso14443a_uid/NdefHelper.cpp
+++ b/Anarcho/SimpleRead_iso14443a_uid/NdefHelper.cpp
@@ -1,6 +1,7 @@
 #include "NdefHelper.h"
 
 #include <ctype.h>
+#include <stdio.h>
 
 bool NdefHelper::parseNextTlv(const uint8_t* start, const uint8_t* end, Tlv& out) const {
 	if (!start || start >= end) return false;
@@ -152,11 +153,12 @@ void NdefHelper::decodeAndPrintTextRecord(const NdefRecord& r) const {
 	Serial.print(F(", "));
 	Serial.print(lang);
 	Serial.println(F(")"));
-	Serial.println(F("Text payload:"));
-	if (utf16) {
-		dumpHexAscii(textPtr, textLen);
-	}
-	else {
+        Serial.println(F("Text payload:"));
+        if (utf16) {
+                String hexDump = getString(textPtr, textLen);
+                Serial.print(hexDump);
+        }
+        else {
 		for (size_t i = 0; i < textLen; ++i) {
 			char c = (char)textPtr[i];
 			Serial.print(isprint((unsigned char)c) ? c : '.');
@@ -165,25 +167,41 @@ void NdefHelper::decodeAndPrintTextRecord(const NdefRecord& r) const {
 	}
 }
 
-void NdefHelper::dumpHexAscii(const uint8_t* data, size_t len) const {
-	Serial.print(F("Data ("));
-	Serial.print(len);
-	Serial.println(F(" bytes):"));
-	for (size_t i = 0; i < len; i += 16) {
-		Serial.printf("%04u: ", (unsigned)i);
-		for (size_t j = 0; j < 16; ++j) {
-			if (i + j < len) {
-				Serial.printf("%02X ", data[i + j]);
-			}
-			else {
-				Serial.print("   ");
-			}
-		}
-		Serial.print(" | ");
-		for (size_t j = 0; j < 16 && (i + j) < len; ++j) {
-			char c = (char)data[i + j];
-			Serial.print(isprint((unsigned char)c) ? c : '.');
-		}
-		Serial.println();
-	}
+String NdefHelper::getString(const uint8_t* data, size_t len) const {
+        String output;
+        size_t estimated = len > 0 ? (((len + 15) / 16) * 80) + 32 : 32;
+        output.reserve(estimated);
+        output += F("Data (");
+        output += len;
+        output += F(" bytes):\n");
+
+        if (!data || len == 0) {
+                return output;
+        }
+
+        for (size_t i = 0; i < len; i += 16) {
+                char offsetBuffer[8];
+                snprintf(offsetBuffer, sizeof(offsetBuffer), "%04u: ", (unsigned)i);
+                output += offsetBuffer;
+
+                for (size_t j = 0; j < 16; ++j) {
+                        if (i + j < len) {
+                                char hexBuffer[4];
+                                snprintf(hexBuffer, sizeof(hexBuffer), "%02X ", data[i + j]);
+                                output += hexBuffer;
+                        }
+                        else {
+                                output += F("   ");
+                        }
+                }
+
+                output += F(" | ");
+                for (size_t j = 0; j < 16 && (i + j) < len; ++j) {
+                        char c = (char)data[i + j];
+                        output += (char)(isprint((unsigned char)c) ? c : '.');
+                }
+                output += '\n';
+        }
+
+        return output;
 }

--- a/Anarcho/SimpleRead_iso14443a_uid/NdefHelper.h
+++ b/Anarcho/SimpleRead_iso14443a_uid/NdefHelper.h
@@ -31,7 +31,7 @@ public:
 	bool parseFirstRecord(const uint8_t* msg, size_t msgLen, NdefRecord& rec) const;
 	bool isTextRecord(const NdefRecord& rec) const;
 	void decodeAndPrintTextRecord(const NdefRecord& rec) const;
-	void dumpHexAscii(const uint8_t* data, size_t len) const;
+        String getString(const uint8_t* data, size_t len) const;
 
 private:
 	bool parseNextTlv(const uint8_t* start, const uint8_t* end, Tlv& out) const;

--- a/Anarcho/SimpleRead_iso14443a_uid/SimpleRead_iso14443a_uid.ino
+++ b/Anarcho/SimpleRead_iso14443a_uid/SimpleRead_iso14443a_uid.ino
@@ -113,8 +113,8 @@ void loop() {
 				return;
 			}
 
-			// Optional: Rohdump
-			// ndefHelper.dumpHexAscii(user, ti.userBytes);
+                        // Optional: Rohdump
+                        // Serial.print(ndefHelper.getString(user, ti.userBytes));
 
 			// --- 3) TLV scannen: NDEF (0x03) finden ---
 			NdefHelper::Tlv tlv{};
@@ -133,8 +133,8 @@ void loop() {
 					}
 					else {
 						Serial.println(F("First NDEF record is not a Text (RTD/T) record."));
-						Serial.println(F("Record header / payload (hex):"));
-						ndefHelper.dumpHexAscii(tlv.value, tlv.length);
+                                                Serial.println(F("Record header / payload (hex):"));
+                                                Serial.print(ndefHelper.getString(tlv.value, tlv.length));
 					}
 				}
 				else {

--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -65,6 +65,37 @@ static void OnPayloadRead(const NdefHelper::NdefRecord &record)
     {
         Logger::LogWarn(F("First NDEF record is not a Text (RTD/T) record."));
         Logger::LogInfo(F("Payload (hex):"));
-        ndefHelper.dumpHexAscii(record.payload, record.payloadLen);
+        const String payloadDump = ndefHelper.getString(record.payload, record.payloadLen);
+        int lineStart = 0;
+        bool firstLine = true;
+        while (lineStart < payloadDump.length())
+        {
+            int lineEnd = payloadDump.indexOf('\n', lineStart);
+            String line = (lineEnd == -1) ? payloadDump.substring(lineStart)
+                                          : payloadDump.substring(lineStart, lineEnd);
+            if (line.length() > 0)
+            {
+                if (firstLine)
+                {
+                    Logger::LogDebug(line);
+                }
+                else
+                {
+                    Logger::LogInfo(line);
+                }
+            }
+            else
+            {
+                Logger::LogInfo();
+            }
+
+            firstLine = false;
+
+            if (lineEnd == -1)
+            {
+                break;
+            }
+            lineStart = lineEnd + 1;
+        }
     }
 }

--- a/Src/Esp32NMCI/src/CardReader/NdefHelper.cpp
+++ b/Src/Esp32NMCI/src/CardReader/NdefHelper.cpp
@@ -1,6 +1,7 @@
 #include "NdefHelper.h"
 #include "../Logger/Logger.h"
 #include <ctype.h>
+#include <stdio.h>
 
 bool NdefHelper::parseNextTlv(const uint8_t *start, const uint8_t *end, Tlv &out) const
 {
@@ -192,7 +193,38 @@ void NdefHelper::decodeAndPrintTextRecord(const NdefRecord &r) const
     Logger::LogInfo(F("Text payload:"));
     if (utf16)
     {
-        dumpHexAscii(textPtr, textLen);
+        const String hexDump = getString(textPtr, textLen);
+        int lineStart = 0;
+        bool firstLine = true;
+        while (lineStart < hexDump.length())
+        {
+            int lineEnd = hexDump.indexOf('\n', lineStart);
+            String line = (lineEnd == -1) ? hexDump.substring(lineStart)
+                                          : hexDump.substring(lineStart, lineEnd);
+            if (line.length() > 0)
+            {
+                if (firstLine)
+                {
+                    Logger::LogDebug(line);
+                }
+                else
+                {
+                    Logger::LogInfo(line);
+                }
+            }
+            else
+            {
+                Logger::LogInfo();
+            }
+
+            firstLine = false;
+
+            if (lineEnd == -1)
+            {
+                break;
+            }
+            lineStart = lineEnd + 1;
+        }
     }
     else
     {
@@ -205,31 +237,48 @@ void NdefHelper::decodeAndPrintTextRecord(const NdefRecord &r) const
     }
 }
 
-void NdefHelper::dumpHexAscii(const uint8_t *data, size_t len) const
+String NdefHelper::getString(const uint8_t *data, size_t len) const
 {
-    Logger::LogDebug(F("Data ("), false);
-    Logger::LogDebug(len, false);
-    Logger::LogDebug(F(" bytes):"));
+    String output;
+    size_t estimated = len > 0 ? (((len + 15) / 16) * 80) + 32 : 32;
+    output.reserve(estimated);
+    output += F("Data (");
+    output += len;
+    output += F(" bytes):\n");
+
+    if (!data || len == 0)
+    {
+        return output;
+    }
+
     for (size_t i = 0; i < len; i += 16)
     {
-        Logger::logf("%04u: ", (unsigned)i);
+        char offsetBuffer[8];
+        snprintf(offsetBuffer, sizeof(offsetBuffer), "%04u: ", static_cast<unsigned int>(i));
+        output += offsetBuffer;
+
         for (size_t j = 0; j < 16; ++j)
         {
             if (i + j < len)
             {
-                Logger::logf("%02X ", data[i + j]);
+                char hexBuffer[4];
+                snprintf(hexBuffer, sizeof(hexBuffer), "%02X ", data[i + j]);
+                output += hexBuffer;
             }
             else
             {
-                Logger::LogInfo("   ", false);
+                output += F("   ");
             }
         }
-        Logger::LogInfo(" | ", false);
+
+        output += F(" | ");
         for (size_t j = 0; j < 16 && (i + j) < len; ++j)
         {
-            char c = (char)data[i + j];
-            Logger::LogInfo(isprint((unsigned char)c) ? c : '.', false);
+            char c = static_cast<char>(data[i + j]);
+            output += static_cast<char>(isprint(static_cast<unsigned char>(c)) ? c : '.');
         }
-        Logger::LogInfo();
+        output += '\n';
     }
+
+    return output;
 }

--- a/Src/Esp32NMCI/src/CardReader/NdefHelper.h
+++ b/Src/Esp32NMCI/src/CardReader/NdefHelper.h
@@ -34,7 +34,7 @@ class NdefHelper
     bool parseFirstRecord(const uint8_t *msg, size_t msgLen, NdefRecord &rec) const;
     bool isTextRecord(const NdefRecord &rec) const;
     void decodeAndPrintTextRecord(const NdefRecord &rec) const;
-    void dumpHexAscii(const uint8_t *data, size_t len) const;
+    String getString(const uint8_t *data, size_t len) const;
 
     private:
     bool parseNextTlv(const uint8_t *start, const uint8_t *end, Tlv &out) const;


### PR DESCRIPTION
## Summary
- replace `NdefHelper::dumpHexAscii` with a new `getString` helper that formats payload bytes into a reusable string
- log the formatted payload string inside `OnPayloadRead` and during UTF-16 text decoding to preserve previous output
- update the example sketch to consume the new string-based helper

## Testing
- not run (Arduino project)


------
https://chatgpt.com/codex/tasks/task_e_68cfdd80bba88323a9155867799304d3