### PR TITLE
Refactor NDEF payload handling to OnNewData callback

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -32,44 +32,12 @@ static Type2TagReader tagReader(nfc);
 
 static NdefHelper ndefHelper;
 static CardReaderManager cardReaderManager(nfc, tagReader, ndefHelper);
-static CardPayloadProcessor cardPayloadProcessor(ndefHelper);
-
-void CardPayloadProcessor::OnPayloadRead(const NdefHelper::NdefRecord &record)
-{
-    Logger::LogInfo(F("OnPayloadRead - payload length: "), false);
-    Logger::LogInfo(static_cast<unsigned long>(record.payloadLen));
-
-    if (!instCardPayloadProcessor_)
-    {
-        Logger::LogError(F("CardPayloadProcessor instance not initialized."));
-        return;
-    }
-
-    if (!record.payload || record.payloadLen == 0)
-    {
-        Logger::LogWarn(F("Received record with empty payload."));
-        return;
-    }
-
-    if (instCardPayloadProcessor_->ndefHelper_.isTextRecord(record))
-    {
-        instCardPayloadProcessor_->ndefHelper_.decodeAndPrintTextRecord(record);
-    }
-    else
-    {
-        Logger::LogWarn(F("First NDEF record is not a Text (RTD/T) record."));
-        Logger::LogDebug(F("Payload (hex):"));
-
-        const String payload = instCardPayloadProcessor_->ndefHelper_.getString(record.payload, record.payloadLen);
-
-        instCardPayloadProcessor_->ProcessPayload(payload);
-    }
-}
+static CardPayloadProcessor cardPayloadProcessor;
 
 void setup()
 {
     Logger::begin(115200, true, Logger::Level::Info);
-    cardReaderManager.setPayloadCallback(CardPayloadProcessor::OnPayloadRead);
+    cardReaderManager.setNewDataCallback(CardPayloadProcessor::OnNewData);
     cardReaderManager.begin();
 }
 

--- a/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.cpp
+++ b/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.cpp
@@ -4,10 +4,20 @@
 
 CardPayloadProcessor *CardPayloadProcessor::instCardPayloadProcessor_ = nullptr;
 
-CardPayloadProcessor::CardPayloadProcessor(NdefHelper &ndefHelper)
-    : ndefHelper_(ndefHelper)
+CardPayloadProcessor::CardPayloadProcessor()
 {
     instCardPayloadProcessor_ = this;
+}
+
+void CardPayloadProcessor::OnNewData(const String &payloadText)
+{
+    if (!instCardPayloadProcessor_)
+    {
+        Logger::LogError(F("CardPayloadProcessor instance not initialized."));
+        return;
+    }
+
+    instCardPayloadProcessor_->ProcessPayload(payloadText);
 }
 
 void CardPayloadProcessor::ProcessPayload(const String &payload)

--- a/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.h
+++ b/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.h
@@ -2,19 +2,16 @@
 
 #include <Arduino.h>
 
-#include "NdefHelper.h"
-
 class CardPayloadProcessor
 {
     public:
-    explicit CardPayloadProcessor(NdefHelper &ndefHelper);
+    CardPayloadProcessor();
 
-    static void OnPayloadRead(const NdefHelper::NdefRecord &record);
+    static void OnNewData(const String &payloadText);
 
     private:
     void ProcessPayload(const String &payload);
     void ProcessPayloadLine(const String &payload, int &lineStart, bool &firstLine, int &retFlag);
 
     static CardPayloadProcessor *instCardPayloadProcessor_;
-    NdefHelper &ndefHelper_;
 };

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
@@ -10,9 +10,9 @@ CardReaderManager::CardReaderManager(PN532 &nfc, Type2TagReader &tagReader, Ndef
 {
 }
 
-void CardReaderManager::setPayloadCallback(PayloadCallback callback)
+void CardReaderManager::setNewDataCallback(NewDataCallback callback)
 {
-    payloadCallback_ = callback;
+    newDataCallback_ = callback;
 }
 
 void CardReaderManager::begin()
@@ -124,7 +124,7 @@ void CardReaderManager::handleTagDetected(const uint8_t *uid, uint8_t uidLength)
         NdefHelper::NdefRecord rec{};
         if (ndefHelper_.parseFirstRecord(tlv.value, tlv.length, rec))
         {
-            notifyPayload(rec);
+            processRecord(rec);
         }
         else
         {
@@ -145,10 +145,88 @@ void CardReaderManager::handleTagRemoved()
     Logger::LogDebug(F("Tag removed"));
 }
 
-void CardReaderManager::notifyPayload(const NdefHelper::NdefRecord &record) const
+void CardReaderManager::processRecord(const NdefHelper::NdefRecord &record)
 {
-    if (payloadCallback_)
+    Logger::LogInfo(F("OnNewData - payload length: "), false);
+    Logger::LogInfo(static_cast<unsigned long>(record.payloadLen));
+
+    String resolvedText;
+    if (!resolvePayloadText(record, resolvedText))
     {
-        payloadCallback_(record);
+        return;
+    }
+
+    notifyNewData(resolvedText);
+}
+
+bool CardReaderManager::resolvePayloadText(const NdefHelper::NdefRecord &record, String &resolvedText) const
+{
+    if (!record.payload || record.payloadLen == 0)
+    {
+        Logger::LogWarn(F("Received record with empty payload."));
+        return false;
+    }
+
+    if (ndefHelper_.isTextRecord(record))
+    {
+        if (record.payloadLen < 1)
+        {
+            Logger::LogInfo(F("Empty RTD/T payload"));
+            return false;
+        }
+
+        uint8_t status = record.payload[0];
+        bool utf16 = (status & 0x80) != 0;
+        uint8_t langLen = (status & 0x3F);
+
+        if (record.payloadLen < static_cast<size_t>(1 + langLen))
+        {
+            Logger::LogInfo(F("RTD/T payload too short"));
+            return false;
+        }
+
+        String lang;
+        for (uint8_t i = 0; i < langLen; ++i)
+        {
+            lang += static_cast<char>(record.payload[1 + i]);
+        }
+
+        const uint8_t *textPtr = record.payload + 1 + langLen;
+        size_t textLen = record.payloadLen - 1 - langLen;
+
+        resolvedText.reserve(lang.length() + textLen + 32);
+        resolvedText = F("NDEF Text: (");
+        resolvedText += utf16 ? F("UTF-16") : F("UTF-8");
+        resolvedText += F(", ");
+        resolvedText += lang;
+        resolvedText += F(")\n");
+        resolvedText += F("Text payload:\n");
+
+        if (utf16)
+        {
+            resolvedText += ndefHelper_.getString(textPtr, textLen);
+        }
+        else
+        {
+            for (size_t i = 0; i < textLen; ++i)
+            {
+                resolvedText += static_cast<char>(textPtr[i]);
+            }
+        }
+
+        return true;
+    }
+
+    Logger::LogWarn(F("First NDEF record is not a Text (RTD/T) record."));
+    Logger::LogDebug(F("Payload (hex):"));
+    resolvedText = ndefHelper_.getString(record.payload, record.payloadLen);
+    return true;
+}
+
+void CardReaderManager::notifyNewData(const String &payloadText) const
+{
+    if (newDataCallback_)
+    {
+        newDataCallback_(payloadText);
     }
 }

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Arduino.h>
 #include <PN532.h>
 #include <stdint.h>
 
@@ -10,24 +11,26 @@
 class CardReaderManager
 {
     public:
-    using PayloadCallback = void (*)(const NdefHelper::NdefRecord &record);
+    using NewDataCallback = void (*)(const String &resolvedPayload);
 
     CardReaderManager(PN532 &nfc, Type2TagReader &tagReader, NdefHelper &ndefHelper);
 
     void begin();
     void process();
 
-    void setPayloadCallback(PayloadCallback callback);
+    void setNewDataCallback(NewDataCallback callback);
 
     private:
     void handleTagDetected(const uint8_t *uid, uint8_t uidLength);
     void handleTagRemoved();
-    void notifyPayload(const NdefHelper::NdefRecord &record) const;
+    void processRecord(const NdefHelper::NdefRecord &record);
+    bool resolvePayloadText(const NdefHelper::NdefRecord &record, String &resolvedText) const;
+    void notifyNewData(const String &payloadText) const;
 
     PN532 &nfc_;
     Type2TagReader &tagReader_;
     NdefHelper &ndefHelper_;
-    PayloadCallback payloadCallback_ = nullptr;
+    NewDataCallback newDataCallback_ = nullptr;
 
     bool tagPresent_ = false;
     uint8_t lastUid_[kUidBufferMax] = {0};


### PR DESCRIPTION
## Summary
- replace the payload callback with an OnNewData callback that delivers resolved text to listeners
- move NDEF record processing into the card reader manager and streamline the card payload processor interface

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cff6a3d81c8323bdeec43d7149a763