### PR TITLE
Refactor payload processing callback

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -33,11 +33,17 @@ static Type2TagReader tagReader(nfc);
 static NdefHelper ndefHelper;
 static CardReaderManager cardReaderManager(nfc, tagReader, ndefHelper);
 static CardPayloadProcessor cardPayloadProcessor;
+static String lastProcessedPayload;
+
+static void OnNewData(const String &payloadText)
+{
+    lastProcessedPayload = cardPayloadProcessor.ProcessPayload(payloadText);
+}
 
 void setup()
 {
     Logger::begin(115200, true, Logger::Level::Info);
-    cardReaderManager.setNewDataCallback(CardPayloadProcessor::OnNewData);
+    cardReaderManager.setNewDataCallback(OnNewData);
     cardReaderManager.begin();
 }
 

--- a/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.cpp
+++ b/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.cpp
@@ -2,38 +2,39 @@
 
 #include "../Logger/Logger.h"
 
-CardPayloadProcessor *CardPayloadProcessor::instCardPayloadProcessor_ = nullptr;
-
-CardPayloadProcessor::CardPayloadProcessor()
-{
-    instCardPayloadProcessor_ = this;
-}
-
-void CardPayloadProcessor::OnNewData(const String &payloadText)
-{
-    if (!instCardPayloadProcessor_)
-    {
-        Logger::LogError(F("CardPayloadProcessor instance not initialized."));
-        return;
-    }
-
-    instCardPayloadProcessor_->ProcessPayload(payloadText);
-}
-
-void CardPayloadProcessor::ProcessPayload(const String &payload)
+String CardPayloadProcessor::ProcessPayload(const String &payload)
 {
     int lineStart = 0;
     bool firstLine = true;
+    bool appendNewline = false;
+    String result;
+    const bool endsWithNewline = payload.length() > 0 && payload.charAt(payload.length() - 1) == '\n';
 
     while (lineStart < payload.length())
     {
         int retFlag;
-        ProcessPayloadLine(payload, lineStart, firstLine, retFlag);
+        const String lineResult = ProcessPayloadLine(payload, lineStart, firstLine, retFlag);
+
+        if (appendNewline)
+        {
+            result += '\n';
+        }
+
+        result += lineResult;
+        appendNewline = true;
+
         if (retFlag == 2) break;
     }
+
+    if (endsWithNewline)
+    {
+        result += '\n';
+    }
+
+    return result;
 }
 
-void CardPayloadProcessor::ProcessPayloadLine(const String &payload, int &lineStart, bool &firstLine, int &retFlag)
+String CardPayloadProcessor::ProcessPayloadLine(const String &payload, int &lineStart, bool &firstLine, int &retFlag)
 {
     retFlag = 1;
     int lineEnd = payload.indexOf('\n', lineStart);
@@ -61,8 +62,11 @@ void CardPayloadProcessor::ProcessPayloadLine(const String &payload, int &lineSt
     if (lineEnd == -1)
     {
         retFlag = 2;
-        return;
+    }
+    else
+    {
+        lineStart = lineEnd + 1;
     }
 
-    lineStart = lineEnd + 1;
+    return line;
 }

--- a/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.h
+++ b/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.h
@@ -5,13 +5,10 @@
 class CardPayloadProcessor
 {
     public:
-    CardPayloadProcessor();
+    CardPayloadProcessor() = default;
 
-    static void OnNewData(const String &payloadText);
+    String ProcessPayload(const String &payload);
 
     private:
-    void ProcessPayload(const String &payload);
-    void ProcessPayloadLine(const String &payload, int &lineStart, bool &firstLine, int &retFlag);
-
-    static CardPayloadProcessor *instCardPayloadProcessor_;
+    String ProcessPayloadLine(const String &payload, int &lineStart, bool &firstLine, int &retFlag);
 };


### PR DESCRIPTION
## Summary
- move the OnNewData callback into the main sketch so it can access the card payload processor instance directly
- have CardPayloadProcessor::ProcessPayload return the processed text while keeping the existing logging behaviour
- keep the latest processed payload text available for additional handling in the sketch

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cffcf209648323b0ea0453854213c4