### PR TITLE
Guard SPIFFS include for environments without ESP32 FS

### DIFF
--- a/Src/Esp32NMCI/Libraries/TFT_eSPI/2.5.43/TFT_eSPI/Processors/TFT_eSPI_ESP32.h
+++ b/Src/Esp32NMCI/Libraries/TFT_eSPI/2.5.43/TFT_eSPI/Processors/TFT_eSPI_ESP32.h
@@ -135,9 +135,26 @@ SPI3_HOST = 2
 #ifdef SMOOTH_FONT
   // Call up the SPIFFS (SPI FLASH Filing System) for the anti-aliased fonts
   #define FS_NO_GLOBALS
-  #include <FS.h>
-  #include "SPIFFS.h" // ESP32 only
-  #define FONT_FS_AVAILABLE
+
+  // Some build environments (e.g. host-based unit tests) do not provide the
+  // ESP32 SPIFFS headers.  Check for them before including so such builds can
+  // fall back to bitmap fonts instead of failing at compile time.
+  #ifdef __has_include
+    #if __has_include(<FS.h>)
+      #include <FS.h>
+    #endif
+    #if __has_include(<SPIFFS.h>)
+      #include <SPIFFS.h>
+      #define FONT_FS_AVAILABLE
+    #elif __has_include(<LittleFS.h>)
+      #include <LittleFS.h>
+      #define FONT_FS_AVAILABLE
+    #endif
+  #else
+    #include <FS.h>
+    #include <SPIFFS.h>
+    #define FONT_FS_AVAILABLE
+  #endif
 #endif
 
 


### PR DESCRIPTION
## Summary
- guard the SPIFFS/LittleFS includes behind availability checks so host builds without ESP32 FS headers still compile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0264d06b88323945d078488c34235