### PR TITLE
Initialize T-Display before showing startup message

### DIFF
--- a/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
+++ b/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
@@ -5,9 +5,15 @@
 
 void DisplayManager::begin()
 {
+    tft.init();
+    tft.setRotation(1);
+
+#ifdef TFT_BL
+    pinMode(TFT_BL, OUTPUT);
+    digitalWrite(TFT_BL, TFT_BACKLIGHT_ON);
+#endif
 
     showMessage("Hello", false);
-    
 }
 
 void DisplayManager::showMessage(const String& message, bool withOverlay) {
@@ -15,18 +21,18 @@ void DisplayManager::showMessage(const String& message, bool withOverlay) {
     tft.setTextDatum(MC_DATUM);  // Mitte zentriert
     tft.setTextColor(TFT_GREEN, TFT_BLACK);
 
-    // Maximale Displaygröße
+    // Maximale DisplaygrÃ¶ÃŸe
     int maxWidth = tft.width() - 10;   // etwas Rand lassen
     int maxHeight = tft.height() - 10;
 
     int bestSize = 1;
-    for (int size = 1; size <= 8; ++size) {  // 1 bis 7 sind vernünftig
+    for (int size = 1; size <= 8; ++size) {  // 1 bis 7 sind vernÃ¼nftig
         tft.setTextSize(size);
         int16_t w = tft.textWidth(message);
-        int16_t h = 8 * size;  // Standardhöhe der Schrift bei Größe 1 = 8px
+        int16_t h = 8 * size;  // StandardhÃ¶he der Schrift bei GrÃ¶ÃŸe 1 = 8px
 
         if (w > maxWidth || h > maxHeight) {
-            break;  // letzte gültige Größe war bestSize
+            break;  // letzte gÃ¼ltige GrÃ¶ÃŸe war bestSize
         }
         bestSize = size;
     }


### PR DESCRIPTION
## Summary
- initialize the TFT_eSPI driver before the DisplayManager renders any text
- ensure the TTGO T-Display backlight pin is enabled so the start message is visible

## Testing
- not run (hardware-dependent project)


------
https://chatgpt.com/codex/tasks/task_e_68d02d25b14c8323967f5d8ba78deac2