### PR TITLE
Add display orientation support to DisplayManager

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -64,7 +64,7 @@ void setup()
 {
     Logger::begin(115200, true, Logger::Level::Info);
 
-    displayManager.begin();
+    displayManager.begin(DisplayManager::Orientation::UsbRight);
 
     cardReaderManager.setNewDataCallback(OnNewData);
     cardReaderManager.begin();

--- a/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
+++ b/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
@@ -3,10 +3,26 @@
 #include "DisplayManager.h"
 #include "../Logger/Logger.h"
 
-void DisplayManager::begin()
+void DisplayManager::begin(Orientation orientation)
 {
     tft.init();
-    tft.setRotation(1);
+
+    // Map the requested physical orientation to the library's rotation indices.
+    uint8_t rotation = 1;
+    switch (orientation)
+    {
+        case Orientation::UsbRight:
+            rotation = 1;
+            break;
+        case Orientation::UsbLeft:
+            rotation = 3;
+            break;
+        default:
+            rotation = 1;
+            break;
+    }
+
+    tft.setRotation(rotation);
 
 #ifdef TFT_BL
     pinMode(TFT_BL, OUTPUT);
@@ -16,7 +32,8 @@ void DisplayManager::begin()
     showMessage("Hello", false);
 }
 
-void DisplayManager::showMessage(const String& message, bool withOverlay) {
+void DisplayManager::showMessage(const String& message, bool withOverlay)
+{
     tft.fillScreen(TFT_BLACK);
     tft.setTextDatum(MC_DATUM);  // Mitte zentriert
     tft.setTextColor(TFT_GREEN, TFT_BLACK);
@@ -40,5 +57,5 @@ void DisplayManager::showMessage(const String& message, bool withOverlay) {
     tft.setTextSize(bestSize);
     tft.drawString(message, tft.width() / 2, tft.height() / 2);
 
-    // drawStatusOverlay();  // Sprite neu zeichnen}
+    // drawStatusOverlay();  // Sprite neu zeichnen
 }

--- a/Src/Esp32NMCI/src/Presentation/DisplayManager.h
+++ b/Src/Esp32NMCI/src/Presentation/DisplayManager.h
@@ -1,13 +1,21 @@
 #pragma once
 #include <TFT_eSPI.h>
 #include <SPI.h>
+#include <stdint.h>
 
 class DisplayManager
 {
 public:
-	void begin();
-	void showMessage(const String& message, bool withOverlay = true);
+    enum class Orientation : uint8_t
+    {
+        UsbRight = 0,
+        UsbLeft = 180,
+    };
+
+    void begin(Orientation orientation = Orientation::UsbRight);
+    void showMessage(const String& message, bool withOverlay = true);
+
 private:
-	TFT_eSPI tft = TFT_eSPI();
+    TFT_eSPI tft = TFT_eSPI();
 };
 


### PR DESCRIPTION
## Summary
- add a display orientation enum so DisplayManager::begin can set 0° or 180° rotation
- map the orientation to the appropriate TFT_eSPI rotation and keep the default behaviour
- update the sketch setup call to use the new orientation argument explicitly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0319f64ac83238e7621f31f240790