### PR TITLE
Integrate display output into logger warnings

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -76,6 +76,7 @@ void setup()
 	Logger::begin(115200, true, Logger::Level::Info);
 
 	displayManager.begin(DisplayManager::Orientation::UsbLeft);
+	Logger::setDisplayManager(&displayManager);
 
 	cardReaderManager.setNewDataCallback(OnNewData);
 	cardReaderManager.begin();

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
@@ -112,7 +112,7 @@ void CardReaderManager::handleTagDetected(const uint8_t *uid, uint8_t uidLength)
 
     if (!tagReader_.readUserMemory(userMemory_, sizeof(userMemory_), ti))
     {
-        Logger::LogError(F("Failed to read user memory"));
+        Logger::LogError(F("Failed to read user memory"), true, Logger::kNoBase, true);
         return;
     }
 

--- a/Src/Esp32NMCI/src/Logger/Logger.cpp
+++ b/Src/Esp32NMCI/src/Logger/Logger.cpp
@@ -4,6 +4,7 @@
 
 bool Logger::s_atLineStart = true;
 Logger::Level Logger::s_filterLevel = Logger::Level::Debug;
+DisplayManager *Logger::s_displayManager = nullptr;
 
 void Logger::begin(unsigned long baudRate, bool waitForSerial, Level filterLevel)
 {
@@ -17,6 +18,11 @@ void Logger::begin(unsigned long baudRate, bool waitForSerial, Level filterLevel
     }
     s_filterLevel = filterLevel;
     s_atLineStart = true;
+}
+
+void Logger::setDisplayManager(DisplayManager *displayManager)
+{
+    s_displayManager = displayManager;
 }
 
 void Logger::log()

--- a/Src/Esp32NMCI/src/Logger/Logger.h
+++ b/Src/Esp32NMCI/src/Logger/Logger.h
@@ -3,6 +3,8 @@
 #include <Arduino.h>
 #include <type_traits>
 
+#include "../Presentation/DisplayManager.h"
+
 class Logger
 {
 public:
@@ -34,6 +36,8 @@ public:
      */
     static void begin(unsigned long baudRate = 115200, bool waitForSerial = true,
                       Level filterLevel = Level::Debug);
+
+    static void setDisplayManager(DisplayManager *displayManager);
 
     /**
      * @brief Emits an empty log line, separating two messages.
@@ -127,9 +131,11 @@ public:
      * @endcode
      */
     template <typename T>
-    static void LogWarn(const T &value, bool newline = true, int base = kNoBase)
+    static void LogWarn(const T &value, bool newline = true, int base = kNoBase,
+                        bool showOnDisplay = false)
     {
         log(value, newline, base, Level::Warn);
+        handleDisplayOutput(value, base, showOnDisplay);
     }
 
     /**
@@ -141,9 +147,11 @@ public:
      * @endcode
      */
     template <typename T>
-    static void LogError(const T &value, bool newline = true, int base = kNoBase)
+    static void LogError(const T &value, bool newline = true, int base = kNoBase,
+                         bool showOnDisplay = false)
     {
         log(value, newline, base, Level::Error);
+        handleDisplayOutput(value, base, showOnDisplay);
     }
 
     /**
@@ -274,6 +282,37 @@ private:
     static bool isLevelEnabled(Level level);
     static uint8_t levelPriority(Level level);
 
+    template <typename T>
+    static void handleDisplayOutput(const T &value, int base, bool showOnDisplay)
+    {
+        if (!showOnDisplay || s_displayManager == nullptr)
+        {
+            return;
+        }
+
+        s_displayManager->showError(makeDisplayString(value, base));
+    }
+
+    template <typename T>
+    static typename std::enable_if<std::is_integral<typename std::decay<T>::type>::value, String>::type
+    makeDisplayString(const T &value, int base)
+    {
+        if (base != kNoBase)
+        {
+            return String(value, static_cast<unsigned char>(base));
+        }
+        return String(value);
+    }
+
+    template <typename T>
+    static typename std::enable_if<!std::is_integral<typename std::decay<T>::type>::value, String>::type
+    makeDisplayString(const T &value, int base)
+    {
+        (void)base;
+        return String(value);
+    }
+
     static bool s_atLineStart;
     static Level s_filterLevel;
+    static DisplayManager *s_displayManager;
 };


### PR DESCRIPTION
## Summary
- connect the logger to the DisplayManager so warnings and errors can optionally be shown on screen
- add a Logger::setDisplayManager hook plus the showOnDisplay flag for LogWarn and LogError
- display the "Failed to read user memory" error on the device display

## Testing
- not run (hardware-specific project)


------
https://chatgpt.com/codex/tasks/task_e_68d066e69e908323a4cc9ea20e550c18