### PR TITLE
Adjust error display to flat text layout

### DIFF
--- a/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
+++ b/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
@@ -70,82 +70,55 @@ void DisplayManager::showError(const String& message, bool withOverlay)
         (void)withOverlay;
 
         tft.fillScreen(TFT_RED);
-        tft.setTextDatum(MC_DATUM);
+        tft.setTextDatum(TL_DATUM);
         tft.setTextColor(TFT_YELLOW, TFT_RED);
 
-        constexpr uint8_t maxLines = 3;
+        constexpr uint8_t maxLines = 4;
         constexpr size_t maxCharactersPerLine = 12;
 
-        std::vector<String> lines;
-        lines.reserve(maxLines);
+        String flattenedMessage;
+        flattenedMessage.reserve(message.length());
 
-        size_t start = 0;
-        const size_t length = message.length();
-
-        while (lines.size() < maxLines && start < length)
+        const size_t originalLength = message.length();
+        for (size_t index = 0; index < originalLength; ++index)
         {
-                while (start < length)
+                const char currentChar = message.charAt(static_cast<unsigned int>(index));
+
+                if (currentChar == '\r' || currentChar == '\n' || currentChar == '\t')
                 {
-                        const char currentChar = message.charAt(start);
-                        if (currentChar == ' ' || currentChar == '\n' || currentChar == '\r' || currentChar == '\t')
-                        {
-                                ++start;
-                                continue;
-                        }
-                        break;
+                        flattenedMessage += ' ';
                 }
-
-                if (start >= length)
+                else
                 {
-                        break;
+                        flattenedMessage += currentChar;
                 }
-
-                const size_t remaining = length - start;
-                size_t endExclusive = start + (remaining < maxCharactersPerLine ? remaining : maxCharactersPerLine);
-
-                const int newlineIndex = message.indexOf('\n', static_cast<unsigned int>(start));
-                int explicitBreakIndex = newlineIndex;
-
-                const int carriageReturnIndex = message.indexOf('\r', static_cast<unsigned int>(start));
-                if (carriageReturnIndex != -1)
-                {
-                        if (explicitBreakIndex == -1 || carriageReturnIndex < explicitBreakIndex)
-                        {
-                                explicitBreakIndex = carriageReturnIndex;
-                        }
-                }
-
-                if (explicitBreakIndex != -1 && static_cast<size_t>(explicitBreakIndex) < endExclusive)
-                {
-                        endExclusive = static_cast<size_t>(explicitBreakIndex);
-                }
-                else if (remaining > maxCharactersPerLine)
-                {
-                        const int spaceIndex = message.lastIndexOf(' ', static_cast<unsigned int>(endExclusive - 1));
-                        if (spaceIndex >= static_cast<int>(start))
-                        {
-                                endExclusive = static_cast<size_t>(spaceIndex);
-                        }
-                }
-
-                String line = message.substring(start, endExclusive);
-                line.trim();
-
-                if (line.length() > 0)
-                {
-                        lines.push_back(line);
-                }
-
-                start = endExclusive;
         }
 
-        if (lines.empty())
+        if (flattenedMessage.length() == 0U)
         {
                 lastDisplayedLines.clear();
                 lastMessageWasList = false;
                 lastMessageValid = false;
                 lastMessageCurrentlyGreen = false;
                 return;
+        }
+
+        std::vector<String> lines;
+        lines.reserve(maxLines);
+
+        size_t startIndex = 0;
+        const size_t flattenedLength = flattenedMessage.length();
+        while (lines.size() < maxLines && startIndex < flattenedLength)
+        {
+                size_t endIndex = startIndex + maxCharactersPerLine;
+                if (endIndex > flattenedLength)
+                {
+                        endIndex = flattenedLength;
+                }
+
+                lines.emplace_back(flattenedMessage.substring(static_cast<unsigned int>(startIndex),
+                                                              static_cast<unsigned int>(endIndex)));
+                startIndex = endIndex;
         }
 
         const int16_t margin = 10;
@@ -184,14 +157,13 @@ void DisplayManager::showError(const String& message, bool withOverlay)
 
         tft.setTextSize(bestSize);
 
-        const size_t lineCount = lines.size();
         const int16_t lineHeight = 8 * bestSize;
-        const int16_t totalVisibleHeight = lineHeight * static_cast<int16_t>(lineCount);
-        const int16_t startY = (tft.height() - totalVisibleHeight) / 2 + (lineHeight / 2);
+        const int16_t totalVisibleHeight = lineHeight * maxLines;
+        const int16_t startY = (tft.height() - totalVisibleHeight) / 2;
 
-        for (size_t i = 0; i < lineCount; ++i)
+        for (size_t i = 0; i < lines.size(); ++i)
         {
-                tft.drawString(lines[i], tft.width() / 2, startY + (lineHeight * static_cast<int16_t>(i)));
+                tft.drawString(lines[i], margin, startY + (lineHeight * static_cast<int16_t>(i)));
         }
 
         lastDisplayedLines.clear();


### PR DESCRIPTION
## Summary
- flatten error messages and wrap them as flow text across four 12-character lines
- render the error text from the top-left without trimming characters so the display shows as much information as possible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d06f02079c8323ae2a89287d430d1d