### PR TITLE
Add deep sleep handling via ButtonManager long press

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -22,6 +22,7 @@
 #include <PN532.h>
 #include <PN532_HSU.h>
 #include <vector>
+#include <esp_sleep.h>
 
 #include "src/config.h"
 #include "src/CardReader/CardReaderManager.h"
@@ -30,6 +31,7 @@
 #include "src/CardReader/Type2TagReader.h"
 #include "src/Logger/Logger.h"
 #include "src/Presentation/DisplayManager.h"
+#include "src/Presentation/ButtonManager.h"
 
 
 /* Card Reader */
@@ -43,10 +45,13 @@ static CardReaderManager cardReaderManager(nfc, tagReader, ndefHelper);
 static CardPayloadProcessor cardPayloadProcessor;
 static std::vector<String> ListElementsInPayloadFromCard;
 static DisplayManager displayManager;
+constexpr int kButtonPin0 = 0;
+constexpr int kButtonPin35 = 35;
+static ButtonManager buttonManager(kButtonPin0, kButtonPin35);
 
 static void OnNewData(const String& payloadText)
 {
-	ListElementsInPayloadFromCard = cardPayloadProcessor.ProcessPayload(payloadText);
+        ListElementsInPayloadFromCard = cardPayloadProcessor.ProcessPayload(payloadText);
 
 	if (ListElementsInPayloadFromCard.empty())
 	{
@@ -71,20 +76,30 @@ static void OnNewData(const String& payloadText)
 
 }
 
+static void EnterDeepSleep()
+{
+        Logger::LogInfo(F("[System] Entering deep sleep"));
+        esp_sleep_enable_ext0_wakeup(GPIO_NUM_35, 0);
+        esp_deep_sleep_start();
+}
+
 void setup()
 {
-	Logger::begin(115200, true, Logger::Level::Info);
+        Logger::begin(115200, true, Logger::Level::Info);
 
-	displayManager.begin(DisplayManager::Orientation::UsbLeft);
-	Logger::setDisplayManager(&displayManager);
+        displayManager.begin(DisplayManager::Orientation::UsbLeft);
+        Logger::setDisplayManager(&displayManager);
 
-	cardReaderManager.setNewDataCallback(OnNewData);
-	cardReaderManager.begin();
+        cardReaderManager.setNewDataCallback(OnNewData);
+        cardReaderManager.begin();
+        buttonManager.begin();
+        buttonManager.setOnButton35LongPressed(EnterDeepSleep);
 }
 
 void loop()
 {
-	cardReaderManager.process();
-	displayManager.update();
+        buttonManager.update();
+        cardReaderManager.process();
+        displayManager.update();
 }
 

--- a/Src/Esp32NMCI/src/Presentation/ButtonManager.cpp
+++ b/Src/Esp32NMCI/src/Presentation/ButtonManager.cpp
@@ -35,11 +35,20 @@ void ButtonManager::update()
     if (!stateB && lastStateB)
     {
         unsigned long duration = millis() - pressStart35;
-        if (duration < longPressThreshold && onButton35Pressed)
+        if (duration >= longPressThreshold)
+        {
+            if (onButton35LongPressed)
+            {
+                Logger::LogInfo(F("[ButtonManager] Button 35 long press"));
+                onButton35LongPressed();
+            }
+        }
+        else if (onButton35Pressed)
         {
             Logger::LogInfo(F("[ButtonManager] Button 35 short press"));
             onButton35Pressed();
         }
+        pressStart35 = 0;
     }
 }
 
@@ -66,4 +75,9 @@ void ButtonManager::setOnButton0Pressed(std::function<void()> callback)
 void ButtonManager::setOnButton35Pressed(std::function<void()> callback)
 {
     onButton35Pressed = callback;
+}
+
+void ButtonManager::setOnButton35LongPressed(std::function<void()> callback)
+{
+    onButton35LongPressed = callback;
 }

--- a/Src/Esp32NMCI/src/Presentation/ButtonManager.h
+++ b/Src/Esp32NMCI/src/Presentation/ButtonManager.h
@@ -17,6 +17,7 @@ class ButtonManager
 
     void setOnButton0Pressed(std::function<void()> callback);
     void setOnButton35Pressed(std::function<void()> callback);
+    void setOnButton35LongPressed(std::function<void()> callback);
 
     private:
     int pinA;
@@ -28,6 +29,7 @@ class ButtonManager
 
     std::function<void()> onButton0Pressed = nullptr;
     std::function<void()> onButton35Pressed = nullptr;
+    std::function<void()> onButton35LongPressed = nullptr;
 
     unsigned long pressStart35 = 0;
     const unsigned long longPressThreshold = 7000; // ms


### PR DESCRIPTION
## Summary
- integrate the ButtonManager into the main sketch, add a deep-sleep helper, and call it when the configured button is held long enough
- extend ButtonManager with a dedicated long-press callback for GPIO 35 to differentiate long and short presses

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d109ab9e5c8323b293438f57725c12