### PR TITLE
Add BLE HID keyboard support to ESP32 project

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -32,6 +32,8 @@
 #include "src/Logger/Logger.h"
 #include "src/Presentation/DisplayManager.h"
 #include "src/Presentation/ButtonManager.h"
+#include "src/HidKeyboard.h"
+#include "src/Helper/Utf8Decoder.h"
 
 
 /* Card Reader */
@@ -48,6 +50,7 @@ static DisplayManager displayManager;
 constexpr int kButtonPin0 = 0;
 constexpr int kButtonPin35 = 35;
 static ButtonManager buttonManager(kButtonPin0, kButtonPin35);
+static HidKeyboard gKeyboard;
 
 static void OnNewData(const String& payloadText)
 {
@@ -94,10 +97,43 @@ void setup()
         cardReaderManager.begin();
         buttonManager.begin();
         buttonManager.setOnButton35LongPressed(EnterDeepSleep);
+
+        Serial.println();
+        Serial.println(F("[BOOT] ESP32 BLE-HID Keyboard (DE) – Boot-Protocol-First"));
+        gKeyboard.begin();
 }
 
 void loop()
 {
+        while (Serial.available())
+        {
+                const uint8_t b = static_cast<uint8_t>(Serial.read());
+
+                uint32_t cp;
+                if (gUtf.feed(b, cp))
+                {
+                        if (cp == '\r')
+                        {
+                                continue;
+                        }
+
+                        if (!gKeyboard.isConnected())
+                        {
+                                if (cp <= 0x7F)
+                                {
+                                        Serial.printf("[WARN] Nicht verbunden: '%c' (0x%02X)\n", static_cast<char>(cp), static_cast<unsigned>(cp));
+                                }
+                                else
+                                {
+                                        Serial.printf("[WARN] Nicht verbunden: U+%04lX\n", static_cast<unsigned long>(cp));
+                                }
+                                continue;
+                        }
+
+                        gKeyboard.typeCodepoint(cp);
+                }
+        }
+
         buttonManager.update();
         cardReaderManager.process();
         displayManager.update();

--- a/Src/Esp32NMCI/Esp32NMCI.vcxproj
+++ b/Src/Esp32NMCI/Esp32NMCI.vcxproj
@@ -43,6 +43,7 @@
     <Import Project="Libraries\TFT_eSPI\2.5.43\TFT_eSPI\TFT_eSPI-2.5.43.vcxitems" Label="Shared" />
     <Import Project="Libraries\SPI\3.3.0\SPI\SPI-3.3.0.vcxitems" Label="Shared" />
     <Import Project="Libraries\FS\2.0.0\FS\FS-2.0.0.vcxitems" Label="Shared" />
+    <Import Project="Libraries\NimBLE-Arduino\2.3.6\NimBLE-Arduino\NimBLE-Arduino-2.3.6.vcxitems" Label="Shared" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
@@ -89,6 +90,8 @@
     <ClCompile Include="src\Logger\Logger.cpp" />
     <ClCompile Include="src\Presentation\ButtonManager.cpp" />
     <ClCompile Include="src\Presentation\DisplayManager.cpp" />
+    <ClCompile Include="src\HidKeyboard.cpp" />
+    <ClCompile Include="src\Helper\Utf8Decoder.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\CardReader\CardReaderManager.h" />
@@ -99,6 +102,9 @@
     <ClInclude Include="src\Logger\Logger.h" />
     <ClInclude Include="src\Presentation\ButtonManager.h" />
     <ClInclude Include="src\Presentation\DisplayManager.h" />
+    <ClInclude Include="src\HidConsts.h" />
+    <ClInclude Include="src\HidKeyboard.h" />
+    <ClInclude Include="src\Helper\Utf8Decoder.h" />
     <ClInclude Include="__vm\.Esp32NMCI.vsarduino.h" />
   </ItemGroup>
   <PropertyGroup>

--- a/Src/Esp32NMCI/Esp32NMCI.vcxproj.filters
+++ b/Src/Esp32NMCI/Esp32NMCI.vcxproj.filters
@@ -18,6 +18,12 @@
     <Filter Include="Src\Logger">
       <UniqueIdentifier>{05281ed2-16e4-4191-9fbf-da97fb3bc6de}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Src\Hid">
+      <UniqueIdentifier>{26256616-C7D3-4640-BE81-AF1B8EA9FE5B}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Src\Helper">
+      <UniqueIdentifier>{507A365B-6937-4B01-B453-DA908BF4BBD5}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Esp32NMCI.ino" />
@@ -41,6 +47,12 @@
     </ClCompile>
     <ClCompile Include="src\Presentation\DisplayManager.cpp">
       <Filter>Src\Presentation</Filter>
+    </ClCompile>
+    <ClCompile Include="src\HidKeyboard.cpp">
+      <Filter>Src\Hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Helper\Utf8Decoder.cpp">
+      <Filter>Src\Helper</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -70,6 +82,15 @@
     </ClInclude>
     <ClInclude Include="src\Presentation\DisplayManager.h">
       <Filter>Src\Presentation</Filter>
+    </ClInclude>
+    <ClInclude Include="src\HidConsts.h">
+      <Filter>Src\Hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\HidKeyboard.h">
+      <Filter>Src\Hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Helper\Utf8Decoder.h">
+      <Filter>Src\Helper</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Src/Esp32NMCI/src/Helper/Utf8Decoder.cpp
+++ b/Src/Esp32NMCI/src/Helper/Utf8Decoder.cpp
@@ -1,0 +1,39 @@
+#include "Utf8Decoder.h"
+
+Utf8Decoder gUtf;
+
+bool Utf8Decoder::feed(uint8_t byte, uint32_t& out) {
+    if (needed == 0) {
+        if (byte < 0x80) {
+            out = byte;
+            return true;
+        }
+        if ((byte & 0xE0) == 0xC0) {
+            codepoint = byte & 0x1F;
+            needed = 1;
+            return false;
+        }
+        if ((byte & 0xF0) == 0xE0) {
+            codepoint = byte & 0x0F;
+            needed = 2;
+            return false;
+        }
+        if ((byte & 0xF8) == 0xF0) {
+            codepoint = byte & 0x07;
+            needed = 3;
+            return false;
+        }
+        return false;
+    }
+
+    if ((byte & 0xC0) != 0x80) {
+        needed = 0;
+        return false;
+    }
+    codepoint = (codepoint << 6) | (byte & 0x3F);
+    if (--needed == 0) {
+        out = codepoint;
+        return true;
+    }
+    return false;
+}

--- a/Src/Esp32NMCI/src/Helper/Utf8Decoder.h
+++ b/Src/Esp32NMCI/src/Helper/Utf8Decoder.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+/**
+ * @brief Incrementally decodes UTF-8 encoded bytes into Unicode code points.
+ *
+ * The decoder keeps track of its progress while bytes are streamed in so that
+ * complete code points can be retrieved once all required bytes are available.
+ */
+struct Utf8Decoder {
+    uint32_t codepoint = 0; ///< Accumulates the current Unicode code point.
+    uint8_t needed = 0;     ///< Remaining continuation bytes for the sequence.
+
+    /**
+     * @brief Feed a single byte of UTF-8 input into the decoder.
+     *
+     * @param byte Next byte of the UTF-8 encoded stream.
+     * @param out  Receives the decoded Unicode code point once complete.
+     * @return True if a full code point was decoded and stored in @p out;
+     *         otherwise false meaning more bytes are required or the input
+     *         sequence was invalid and has been discarded.
+     */
+    bool feed(uint8_t byte, uint32_t& out);
+};
+
+/**
+ * @brief Global decoder instance used for handling serial input.
+ */
+extern Utf8Decoder gUtf;

--- a/Src/Esp32NMCI/src/HidConsts.h
+++ b/Src/Esp32NMCI/src/HidConsts.h
@@ -1,0 +1,145 @@
+/**
+ * @file HidConsts.h
+ * @brief Stellt Konstanten und Report-Definitionen für das HID-Tastaturprofil bereit.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+ // ---------- HID Keycodes / Modifier Fallbacks ----------
+#ifndef HID_KEY_ENTER
+#define HID_KEY_A              0x04
+#define HID_KEY_B              0x05
+#define HID_KEY_C              0x06
+#define HID_KEY_D              0x07
+#define HID_KEY_E              0x08
+#define HID_KEY_F              0x09
+#define HID_KEY_G              0x0A
+#define HID_KEY_H              0x0B
+#define HID_KEY_I              0x0C
+#define HID_KEY_J              0x0D
+#define HID_KEY_K              0x0E
+#define HID_KEY_L              0x0F
+#define HID_KEY_M              0x10
+#define HID_KEY_N              0x11
+#define HID_KEY_O              0x12
+#define HID_KEY_P              0x13
+#define HID_KEY_Q              0x14
+#define HID_KEY_R              0x15
+#define HID_KEY_S              0x16
+#define HID_KEY_T              0x17
+#define HID_KEY_U              0x18
+#define HID_KEY_V              0x19
+#define HID_KEY_W              0x1A
+#define HID_KEY_X              0x1B
+#define HID_KEY_Y              0x1C
+#define HID_KEY_Z              0x1D
+#define HID_KEY_1              0x1E
+#define HID_KEY_2              0x1F
+#define HID_KEY_3              0x20
+#define HID_KEY_4              0x21
+#define HID_KEY_5              0x22
+#define HID_KEY_6              0x23
+#define HID_KEY_7              0x24
+#define HID_KEY_8              0x25
+#define HID_KEY_9              0x26
+#define HID_KEY_0              0x27
+#define HID_KEY_ENTER          0x28
+#define HID_KEY_ESCAPE         0x29
+#define HID_KEY_BACKSPACE      0x2A
+#define HID_KEY_TAB            0x2B
+#define HID_KEY_SPACEBAR       0x2C
+#define HID_KEY_MINUS          0x2D
+#define HID_KEY_EQUAL          0x2E
+#define HID_KEY_LEFT_BRACKET   0x2F
+#define HID_KEY_RIGHT_BRACKET  0x30
+#define HID_KEY_BACKSLASH      0x31
+#define HID_KEY_SEMICOLON      0x33
+#define HID_KEY_APOSTROPHE     0x34
+#define HID_KEY_GRAVE          0x35
+#define HID_KEY_COMMA          0x36
+#define HID_KEY_PERIOD         0x37
+#define HID_KEY_SLASH          0x38
+#define HID_KEY_NON_US_BACKSLASH 0x64
+#endif
+
+#ifndef KEYBOARD_MODIFIER_LEFTSHIFT
+#define KEYBOARD_MODIFIER_LEFTCTRL    0x01
+#define KEYBOARD_MODIFIER_LEFTSHIFT   0x02
+#define KEYBOARD_MODIFIER_LEFTALT     0x04
+#define KEYBOARD_MODIFIER_LEFTGUI     0x08
+#define KEYBOARD_MODIFIER_RIGHTCTRL   0x10
+#define KEYBOARD_MODIFIER_RIGHTSHIFT  0x20
+#define KEYBOARD_MODIFIER_RIGHTALT    0x40 // AltGr
+#define KEYBOARD_MODIFIER_RIGHTGUI    0x80
+#endif
+
+// ---------- UUIDs ----------
+
+// Primärer Dienst, über den das Gerät als HID-Tastatur identifiziert wird.
+static const uint16_t UUID_HID_SERVICE = 0x1812;
+
+// Characteristic mit den allgemeinen Geräteeigenschaften (Version, Landeskode, Flags).
+static const uint16_t UUID_HID_INFORMATION = 0x2A4A;
+
+// Characteristic, welche die gesamte HID-Report-Map (Layout der Reports) bereitstellt.
+static const uint16_t UUID_REPORT_MAP = 0x2A4B;
+
+// Characteristic, über die der Host das Gerät z. B. in den Suspend-Zustand schicken kann.
+static const uint16_t UUID_HID_CONTROL_POINT = 0x2A4C;
+
+// Characteristic für die eigentlichen HID-Reports (Input, Output und Feature Reports).
+static const uint16_t UUID_REPORT = 0x2A4D;
+
+// Characteristic zum Umschalten zwischen Boot- und Report-Protokollmodus.
+static const uint16_t UUID_PROTOCOL_MODE = 0x2A4E;
+
+// Boot-Protokoll-Eingabereport für Tastaturen (wird vor allem von BIOS/UEFI genutzt).
+
+static const uint16_t UUID_BOOT_KB_INPUT = 0x2A22;
+
+// Boot-Protokoll-Ausgabereport für Tastaturen (z. B. LED-Steuerung wie CapsLock).
+static const uint16_t UUID_BOOT_KB_OUTPUT = 0x2A32;
+
+// Descriptor, der zu einem Report die Report-ID und den Report-Typ referenziert.
+static const uint16_t UUID_RPT_REF_DESC = 0x2908;
+
+// ---------- Report-Map ----------
+
+/*
+ * KEYBOARD_REPORTMAP beschreibt den Aufbau des vom Gerät gelieferten HID-Tastaturreports:
+ *  - Die ersten Einträge (0x05, 0x01, 0x09, 0x06, 0xA1, 0x01) setzen Usage Page und Usage
+ *    auf "Generic Desktop / Keyboard" und eröffnen die Application Collection.
+ *  - Die darauffolgenden Definitionen (Report-ID 1) legen acht Eingabebits für die Modifier
+ *    E0..E7 fest, gefolgt von einem reservierten Byte zur Kompatibilität mit dem Boot-Protokoll.
+ *  - Danach folgt ein LED-Output-Report mit fünf Bits (NumLock bis Kana) sowie drei Padding-Bits.
+ *  - Der abschließende Abschnitt definiert sechs Byte breite Keycode-Slots für bis zu sechs
+ *    gleichzeitig gedrückte Tasten im Bereich 0x00 bis 0x65 (Standard 6-Key-Rollover).
+ */
+static const uint8_t KEYBOARD_REPORTMAP[] = {
+  0x05, 0x01, 0x09, 0x06, 0xA1, 0x01,
+	0x85, 0x01,                   // Report ID = 1 (Input)
+	0x05, 0x07,
+	0x19, 0xE0, 0x29, 0xE7,       // Modifiers
+	0x15, 0x00, 0x25, 0x01,
+	0x75, 0x01, 0x95, 0x08,
+	0x81, 0x02,                   // Input (Data,Var,Abs)
+
+	0x75, 0x08, 0x95, 0x01,
+	0x81, 0x01,                   // Reserved
+
+	0x05, 0x08,
+	0x19, 0x01, 0x29, 0x05,       // LEDs
+	0x75, 0x01, 0x95, 0x05,
+	0x91, 0x02,                   // Output (Data,Var,Abs)
+	0x75, 0x03, 0x95, 0x01,
+	0x91, 0x01,                   // Output (Const,Arr,Abs) padding
+
+	0x05, 0x07,
+	0x19, 0x00, 0x29, 0x65,       // Keys 0..101
+	0x15, 0x00, 0x25, 0x65,
+	0x75, 0x08, 0x95, 0x06,
+	0x81, 0x00,                   // Input (Data,Arr,Abs)
+  0xC0
+};

--- a/Src/Esp32NMCI/src/HidKeyboard.cpp
+++ b/Src/Esp32NMCI/src/HidKeyboard.cpp
@@ -1,0 +1,404 @@
+#include "HidKeyboard.h"
+
+#include <Arduino.h>
+
+#include "HidConsts.h"
+
+#if !defined(NIMBLE_CPP_CONNINFO_H_)
+#    if defined(__has_include)
+#        if __has_include(<NimBLEConnInfo.h>)
+#            include <NimBLEConnInfo.h>
+#        endif
+#    endif
+#endif
+
+#if defined(NIMBLE_CPP_CONNINFO_H_)
+#    define HID_KEYBOARD_HAS_CONN_INFO 1
+#else
+#    define HID_KEYBOARD_HAS_CONN_INFO 0
+#endif
+
+class HidKeyboardProtocolModeCallbacks : public NimBLECharacteristicCallbacks {
+public:
+    explicit HidKeyboardProtocolModeCallbacks(HidKeyboard& keyboard) : mKeyboard(keyboard) {}
+
+#if HID_KEYBOARD_HAS_CONN_INFO
+    void onWrite(NimBLECharacteristic* characteristic, NimBLEConnInfo&) override {
+        mKeyboard.handleProtocolModeWrite(characteristic);
+    }
+#else
+    void onWrite(NimBLECharacteristic* characteristic) override {
+        mKeyboard.handleProtocolModeWrite(characteristic);
+    }
+#endif
+
+private:
+    HidKeyboard& mKeyboard;
+};
+
+class HidKeyboardInputSubscribeCallbacks : public NimBLECharacteristicCallbacks {
+public:
+    explicit HidKeyboardInputSubscribeCallbacks(HidKeyboard& keyboard) : mKeyboard(keyboard) {}
+
+#if HID_KEYBOARD_HAS_CONN_INFO
+    void onSubscribe(
+        NimBLECharacteristic* characteristic,
+        NimBLEConnInfo&,
+        uint16_t subValue) override {
+        mKeyboard.handleSubscription(characteristic, subValue);
+    }
+#else
+    void onSubscribe(
+        NimBLECharacteristic* characteristic,
+        ble_gap_conn_desc*,
+        uint16_t subValue) override {
+        mKeyboard.handleSubscription(characteristic, subValue);
+    }
+#endif
+
+private:
+    HidKeyboard& mKeyboard;
+};
+
+class HidKeyboardServerCallbacks : public NimBLEServerCallbacks {
+public:
+    explicit HidKeyboardServerCallbacks(HidKeyboard& keyboard) : mKeyboard(keyboard) {}
+
+#if HID_KEYBOARD_HAS_CONN_INFO
+    void onConnect(NimBLEServer*, NimBLEConnInfo&) override {
+        mKeyboard.afterConnect();
+    }
+
+    void onDisconnect(NimBLEServer*, NimBLEConnInfo&, int) override {
+        mKeyboard.afterDisconnect();
+    }
+#else
+    void onConnect(NimBLEServer*) override {
+        mKeyboard.afterConnect();
+    }
+
+    void onDisconnect(NimBLEServer*) override {
+        mKeyboard.afterDisconnect();
+    }
+#endif
+
+private:
+    HidKeyboard& mKeyboard;
+};
+
+HidKeyboard::HidKeyboard()
+    : mInputReport(nullptr)
+    , mBootIn(nullptr)
+    , mAdv(nullptr)
+    , mConnected(false)
+    , mProtocolMode(0x00)
+    , mSubBootIn(false)
+    , mSubReport(false)
+    , mProtoCb(std::make_unique<HidKeyboardProtocolModeCallbacks>(*this))
+    , mSubCb(std::make_unique<HidKeyboardInputSubscribeCallbacks>(*this))
+    , mServerCb(std::make_unique<HidKeyboardServerCallbacks>(*this)) {
+}
+
+HidKeyboard::~HidKeyboard() = default;
+
+void HidKeyboard::begin() {
+    NimBLEDevice::init("ESP32 DE Keyboard");
+    NimBLEDevice::setSecurityIOCap(BLE_HS_IO_NO_INPUT_OUTPUT);
+    NimBLEDevice::setSecurityAuth(true, false, true);
+    NimBLEDevice::setPower(ESP_PWR_LVL_P9);
+
+    NimBLEServer* server = NimBLEDevice::createServer();
+    server->setCallbacks(mServerCb.get());
+
+    NimBLEService* hid = server->createService((uint16_t)UUID_HID_SERVICE);
+
+    NimBLECharacteristic* chProtocol = hid->createCharacteristic(
+        (uint16_t)UUID_PROTOCOL_MODE,
+        NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE_NR
+    );
+    chProtocol->setCallbacks(mProtoCb.get());
+    chProtocol->setValue(&mProtocolMode, 1);
+
+    NimBLECharacteristic* chHidInfo = hid->createCharacteristic(
+        (uint16_t)UUID_HID_INFORMATION,
+        NIMBLE_PROPERTY::READ
+    );
+    uint8_t hidInfo[4] = { 0x11, 0x01, 0x00, 0x02 };
+    chHidInfo->setValue(hidInfo, sizeof(hidInfo));
+
+    NimBLECharacteristic* chCtrlPt = hid->createCharacteristic(
+        (uint16_t)UUID_HID_CONTROL_POINT,
+        NIMBLE_PROPERTY::WRITE_NR
+    );
+    uint8_t ctl = 0x00;
+    chCtrlPt->setValue(&ctl, 1);
+
+    NimBLECharacteristic* chReportMap = hid->createCharacteristic(
+        (uint16_t)UUID_REPORT_MAP,
+        NIMBLE_PROPERTY::READ
+    );
+    chReportMap->setValue((uint8_t*)KEYBOARD_REPORTMAP, sizeof(KEYBOARD_REPORTMAP));
+
+    mInputReport = hid->createCharacteristic(
+        (uint16_t)UUID_REPORT,
+        NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY
+    );
+    {
+        NimBLEDescriptor* repRef = mInputReport->createDescriptor(
+            (uint16_t)UUID_RPT_REF_DESC, NIMBLE_PROPERTY::READ, 2
+        );
+        uint8_t repRefVal[2] = { 0x01, 0x01 };
+        repRef->setValue(repRefVal, sizeof(repRefVal));
+    }
+    mInputReport->setCallbacks(mSubCb.get());
+
+    mBootIn = hid->createCharacteristic(
+        (uint16_t)UUID_BOOT_KB_INPUT,
+        NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY
+    );
+    mBootIn->setCallbacks(mSubCb.get());
+
+    hid->createCharacteristic(
+        (uint16_t)UUID_BOOT_KB_OUTPUT,
+        NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_NR
+    );
+
+    hid->start();
+
+    NimBLEService* dis = server->createService((uint16_t)0x180A);
+    NimBLECharacteristic* cMan = dis->createCharacteristic((uint16_t)0x2A29, NIMBLE_PROPERTY::READ);
+    cMan->setValue("TestCo");
+    dis->start();
+
+    mAdv = NimBLEDevice::getAdvertising();
+    mAdv->addServiceUUID((uint16_t)UUID_HID_SERVICE);
+    mAdv->setAppearance(961);
+    mAdv->start();
+
+    Serial.println("[BLE] Advertising als HID Keyboard. Bei Service-Änderungen Bond löschen & neu koppeln.");
+    Serial.println("[INFO] Im seriellen Monitor tippen; Enter = Zeilenumbruch. (UTF-8)");
+}
+
+bool HidKeyboard::isConnected() const {
+    return mConnected;
+}
+
+void HidKeyboard::typeCodepoint(uint32_t cp) {
+    uint8_t mods;
+    uint8_t key;
+    if (!cpToHid_DE(cp, mods, key)) {
+        if (cp <= 0x7F) {
+            Serial.printf("[HID] Unmapped ASCII: 0x%02X '%c'\n", (unsigned)cp, (char)cp);
+        } else {
+            Serial.printf("[HID] Unmapped U+%04lX\n", (unsigned long)cp);
+        }
+        return;
+    }
+    pressAndRelease(mods, key);
+}
+
+void HidKeyboard::handleProtocolModeWrite(NimBLECharacteristic* characteristic) {
+    std::string value = characteristic->getValue();
+    if (value.size() == 1 && (value[0] == 0x00 || value[0] == 0x01)) {
+        mProtocolMode = static_cast<uint8_t>(value[0]);
+        Serial.printf("[HID] Host set ProtocolMode = %s\n", mProtocolMode ? "Report(1)" : "Boot(0)");
+    }
+}
+
+void HidKeyboard::handleSubscription(NimBLECharacteristic* characteristic, uint16_t subValue) {
+    const bool notifyEnabled = (subValue & 0x0001);
+    if (characteristic == mBootIn) {
+        mSubBootIn = notifyEnabled;
+        Serial.printf("[HID] BootInput subscribe = %d\n", static_cast<int>(mSubBootIn));
+    } else if (characteristic == mInputReport) {
+        mSubReport = notifyEnabled;
+        Serial.printf("[HID] ReportInput subscribe = %d\n", static_cast<int>(mSubReport));
+    }
+}
+
+void HidKeyboard::afterConnect() {
+    mConnected = true;
+    Serial.println("[BLE] Verbunden");
+    unsigned long t0 = millis();
+    while (millis() - t0 < 800) {
+        delay(1);
+    }
+
+    auto sendRelease = [this]() {
+        uint8_t rpt[8] = { 0,0,0,0,0,0,0,0 };
+        if (mBootIn) {
+            mBootIn->setValue(rpt, sizeof(rpt));
+            mBootIn->notify();
+        }
+        if (mInputReport) {
+            mInputReport->setValue(rpt, sizeof(rpt));
+            mInputReport->notify();
+        }
+    };
+
+    uint8_t rptA[8] = { KEYBOARD_MODIFIER_LEFTSHIFT, 0, HID_KEY_A, 0,0,0,0,0 };
+    uint8_t rptEnter[8] = { 0,0, HID_KEY_ENTER, 0,0,0,0,0 };
+
+    if (mBootIn) {
+        mBootIn->setValue(rptA, sizeof(rptA));
+        mBootIn->notify();
+    }
+    if (mInputReport) {
+        mInputReport->setValue(rptA, sizeof(rptA));
+        mInputReport->notify();
+    }
+    delay(10);
+    sendRelease();
+    delay(10);
+
+    if (mBootIn) {
+        mBootIn->setValue(rptEnter, sizeof(rptEnter));
+        mBootIn->notify();
+    }
+    if (mInputReport) {
+        mInputReport->setValue(rptEnter, sizeof(rptEnter));
+        mInputReport->notify();
+    }
+    delay(10);
+    sendRelease();
+
+    Serial.printf("[HID] ProtocolMode on connect (may change) = %s\n", mProtocolMode ? "Report(1)" : "Boot(0)");
+}
+
+void HidKeyboard::afterDisconnect() {
+    mConnected = false;
+    mSubBootIn = false;
+    mSubReport = false;
+    Serial.println("[BLE] Getrennt. Advertising neu...");
+    NimBLEDevice::startAdvertising();
+}
+
+void HidKeyboard::sendKeyReportRaw(
+    NimBLECharacteristic* characteristic,
+    const char* tag,
+    uint8_t mods,
+    uint8_t k1,
+    uint8_t k2,
+    uint8_t k3,
+    uint8_t k4,
+    uint8_t k5,
+    uint8_t k6) {
+    if (!characteristic) {
+        return;
+    }
+    uint8_t rpt[8] = { mods, 0x00, k1, k2, k3, k4, k5, k6 };
+    characteristic->setValue(rpt, sizeof(rpt));
+    bool ok = characteristic->notify();
+    Serial.printf("[HID] send %s notify=%d mods=%02X keys=%02X %02X %02X %02X %02X %02X\n",
+        tag,
+        static_cast<int>(ok),
+        mods,
+        k1,
+        k2,
+        k3,
+        k4,
+        k5,
+        k6);
+}
+
+void HidKeyboard::sendKeyReport(
+    uint8_t mods,
+    uint8_t k1,
+    uint8_t k2,
+    uint8_t k3,
+    uint8_t k4,
+    uint8_t k5,
+    uint8_t k6) {
+    if (!mConnected) {
+        return;
+    }
+
+    if (mProtocolMode == 0x00) {
+        if (mSubBootIn) {
+            sendKeyReportRaw(mBootIn, "Boot", mods, k1, k2, k3, k4, k5, k6);
+            return;
+        }
+    } else {
+        if (mSubReport) {
+            sendKeyReportRaw(mInputReport, "Report", mods, k1, k2, k3, k4, k5, k6);
+            return;
+        }
+    }
+
+    sendKeyReportRaw(mBootIn, "Boot*", mods, k1, k2, k3, k4, k5, k6);
+    sendKeyReportRaw(mInputReport, "Report*", mods, k1, k2, k3, k4, k5, k6);
+}
+
+void HidKeyboard::pressAndRelease(uint8_t mods, uint8_t key) {
+    sendKeyReport(mods, key);
+    delay(8);
+    sendKeyReport(0);
+    delay(5);
+}
+
+bool HidKeyboard::cpToHid_DE(uint32_t cp, uint8_t& mods, uint8_t& key) {
+    mods = 0;
+    if (cp == '\n' || cp == '\r') { key = HID_KEY_ENTER; return true; }
+    if (cp == '\t') { key = HID_KEY_TAB; return true; }
+    if (cp == ' ') { key = HID_KEY_SPACEBAR; return true; }
+
+    if (cp >= '1' && cp <= '9') { key = static_cast<uint8_t>(HID_KEY_1 + (cp - '1')); return true; }
+    if (cp == '0') { key = HID_KEY_0; return true; }
+
+    if (cp >= 'a' && cp <= 'z') {
+        if (cp == 'z') { key = HID_KEY_Y; return true; }
+        if (cp == 'y') { key = HID_KEY_Z; return true; }
+        key = static_cast<uint8_t>(HID_KEY_A + (cp - 'a'));
+        return true;
+    }
+    if (cp >= 'A' && cp <= 'Z') {
+        if (cp == 'Z') { key = HID_KEY_Y; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true; }
+        if (cp == 'Y') { key = HID_KEY_Z; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true; }
+        key = static_cast<uint8_t>(HID_KEY_A + (cp - 'A'));
+        mods = KEYBOARD_MODIFIER_LEFTSHIFT;
+        return true;
+    }
+
+    switch (cp) {
+    case 0x00E4: key = HID_KEY_APOSTROPHE; return true;
+    case 0x00C4: key = HID_KEY_APOSTROPHE; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case 0x00F6: key = HID_KEY_SEMICOLON;  return true;
+    case 0x00D6: key = HID_KEY_SEMICOLON;  mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case 0x00FC: key = HID_KEY_LEFT_BRACKET; return true;
+    case 0x00DC: key = HID_KEY_LEFT_BRACKET; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case 0x00DF: key = HID_KEY_MINUS; return true;
+    case 0x20AC: mods = KEYBOARD_MODIFIER_RIGHTALT; key = HID_KEY_E; return true;
+    }
+
+    switch (cp) {
+    case '.': key = HID_KEY_PERIOD; return true;
+    case ',': key = HID_KEY_COMMA; return true;
+    case '-': key = HID_KEY_SLASH; return true;
+    case '_': key = HID_KEY_SLASH; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case '+': key = HID_KEY_RIGHT_BRACKET; return true;
+    case '*': key = HID_KEY_RIGHT_BRACKET; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case ':': key = HID_KEY_PERIOD; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case ';': key = HID_KEY_COMMA;  mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case '!': key = HID_KEY_1; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case '?': key = HID_KEY_MINUS; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case '=': key = HID_KEY_EQUAL; return true;
+
+    case '/':  key = HID_KEY_7;  mods = KEYBOARD_MODIFIER_RIGHTALT; return true;
+    case '\\': key = HID_KEY_MINUS; mods = KEYBOARD_MODIFIER_RIGHTALT; return true;
+    case '#':  key = HID_KEY_BACKSLASH; return true;
+    case '"':  key = HID_KEY_2; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case '\'': key = HID_KEY_BACKSLASH; mods = KEYBOARD_MODIFIER_RIGHTALT; return true;
+
+    case '(': key = HID_KEY_8; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case ')': key = HID_KEY_9; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case '[': key = HID_KEY_8; mods = KEYBOARD_MODIFIER_RIGHTALT; return true;
+    case ']': key = HID_KEY_9; mods = KEYBOARD_MODIFIER_RIGHTALT; return true;
+    case '{': key = HID_KEY_7; mods = KEYBOARD_MODIFIER_RIGHTALT; return true;
+    case '}': key = HID_KEY_0; mods = KEYBOARD_MODIFIER_RIGHTALT; return true;
+    case '<': key = HID_KEY_NON_US_BACKSLASH; return true;
+    case '>': key = HID_KEY_NON_US_BACKSLASH; mods = KEYBOARD_MODIFIER_LEFTSHIFT; return true;
+    case '|': key = HID_KEY_NON_US_BACKSLASH; mods = KEYBOARD_MODIFIER_RIGHTALT; return true;
+    }
+    return false;
+}
+

--- a/Src/Esp32NMCI/src/HidKeyboard.h
+++ b/Src/Esp32NMCI/src/HidKeyboard.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <NimBLEDevice.h>
+#include <stdint.h>
+#include <memory>
+
+class HidKeyboardProtocolModeCallbacks;
+class HidKeyboardInputSubscribeCallbacks;
+class HidKeyboardServerCallbacks;
+
+/**
+ * @brief Verwaltet alle BLE-HID-Funktionen für das virtuelle Keyboard.
+ */
+class HidKeyboard {
+public:
+	/**
+	 * @brief Konstruktor initialisiert alle Pointer und Statusvariablen.
+	 */
+	HidKeyboard();
+
+	/**
+	 * @brief Destruktor sorgt für die Freigabe der Callback-Objekte.
+	 */
+	~HidKeyboard();
+
+	/**
+	 * @brief Initialisiert NimBLE, richtet den HID-Service ein und startet Advertising.
+	 */
+	void begin();
+
+	/**
+	 * @brief Gibt zurück, ob aktuell ein zentraler BLE-Client verbunden ist.
+	 */
+	bool isConnected() const;
+
+	/**
+	 * @brief Konvertiert einen Unicode-Codepoint und sendet ihn als Tastendruck.
+	 *
+	 * Für nicht unterstützte Zeichen werden Diagnosemeldungen im Seriellen Monitor ausgegeben.
+	 */
+	void typeCodepoint(uint32_t cp);
+
+private:
+	friend class HidKeyboardProtocolModeCallbacks;
+	friend class HidKeyboardInputSubscribeCallbacks;
+	friend class HidKeyboardServerCallbacks;
+
+	/**
+	 * @brief Verarbeitet Schreibzugriffe auf die Protocol-Mode-Charakteristik.
+	 */
+	void handleProtocolModeWrite(NimBLECharacteristic* characteristic);
+
+	/**
+	 * @brief Aktualisiert den Subskriptionsstatus für Boot- und Report-Input.
+	 */
+	void handleSubscription(NimBLECharacteristic* characteristic, uint16_t subValue);
+
+	/**
+	 * @brief Bereitet das Gerät nach erfolgreichem Verbindungsaufbau vor.
+	 */
+	void afterConnect();
+
+	/**
+	 * @brief Setzt den Status nach einem Verbindungsabbruch zurück und startet Advertising.
+	 */
+	void afterDisconnect();
+
+	/**
+	 * @brief Sendet einen Rohreport an die angegebene Charakteristik.
+	 */
+	void sendKeyReportRaw(
+		NimBLECharacteristic* characteristic,
+		const char* tag,
+		uint8_t mods,
+		uint8_t k1 = 0,
+		uint8_t k2 = 0,
+		uint8_t k3 = 0,
+		uint8_t k4 = 0,
+		uint8_t k5 = 0,
+		uint8_t k6 = 0);
+
+	/**
+	 * @brief Sendet einen Report unter Berücksichtigung des aktiven Protokolls.
+	 */
+	void sendKeyReport(
+		uint8_t mods,
+		uint8_t k1 = 0,
+		uint8_t k2 = 0,
+		uint8_t k3 = 0,
+		uint8_t k4 = 0,
+		uint8_t k5 = 0,
+		uint8_t k6 = 0);
+
+	/**
+	 * @brief Sendet einen Tastendruck mit anschließendem Release.
+	 */
+	void pressAndRelease(uint8_t mods, uint8_t key);
+
+	/**
+	 * @brief Wandelt einen Codepoint ins deutsche HID-Layout um.
+	 */
+	bool cpToHid_DE(uint32_t cp, uint8_t& mods, uint8_t& key);
+
+	NimBLECharacteristic* mInputReport;
+	NimBLECharacteristic* mBootIn;
+	NimBLEAdvertising* mAdv;
+	volatile bool mConnected;
+	uint8_t mProtocolMode;
+	volatile bool mSubBootIn;
+	volatile bool mSubReport;
+	std::unique_ptr<HidKeyboardProtocolModeCallbacks> mProtoCb;
+	std::unique_ptr<HidKeyboardInputSubscribeCallbacks> mSubCb;
+	std::unique_ptr<HidKeyboardServerCallbacks> mServerCb;
+};
+


### PR DESCRIPTION
## Summary
- integrate the HID keyboard implementation from the proof-of-concept into the Esp32NMCI sketch
- add the UTF-8 serial decoder and BLE keyboard hookup so serial input is forwarded to the HID service
- register the NimBLE library and new sources with the Visual Micro project files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d15015102c8323bb41fab8077cb59f