### PR TITLE
Document BLE HID keyboard internals

### DIFF
--- a/Src/Esp32NMCI/src/HidKeyboard.cpp
+++ b/Src/Esp32NMCI/src/HidKeyboard.cpp
@@ -86,6 +86,9 @@ private:
     HidKeyboard& mKeyboard;
 };
 
+///
+/// Konstruktor: initialisiert sämtliche Statuszeiger und Callback-Wrapper.
+///
 HidKeyboard::HidKeyboard()
     : mInputReport(nullptr)
     , mBootIn(nullptr)
@@ -101,6 +104,15 @@ HidKeyboard::HidKeyboard()
 
 HidKeyboard::~HidKeyboard() = default;
 
+/**
+ * Initialisiert den NimBLE-Stack, legt den HID-Service samt
+ * Charakteristiken an und startet anschließendes Advertising.
+ *
+ * Die Methode richtet ebenfalls einen Device-Information-Service ein und
+ * hinterlegt die Report-Map, in der der Report mit der ID 0x01 definiert ist.
+ * Dadurch weiß der Host, dass im Report-Modus ein führendes Report-ID-Byte
+ * zu erwarten ist.
+ */
 void HidKeyboard::begin() {
     NimBLEDevice::init("ESP32 DE Keyboard");
     NimBLEDevice::setSecurityIOCap(BLE_HS_IO_NO_INPUT_OUTPUT);
@@ -179,10 +191,20 @@ void HidKeyboard::begin() {
     Serial.println("[INFO] Im seriellen Monitor tippen; Enter = Zeilenumbruch. (UTF-8)");
 }
 
+/**
+ * Gibt an, ob aktuell eine BLE-Verbindung besteht.
+ */
 bool HidKeyboard::isConnected() const {
     return mConnected;
 }
 
+/**
+ * Übersetzt einen UTF-32-Codepoint ins deutsche Tastaturlayout und sendet
+ * anschließend einen Press/Release-Zyklus.
+ *
+ * Nicht abbildbare Zeichen erzeugen lediglich eine Debug-Ausgabe, so dass der
+ * Aufrufer über fehlende Zuordnungen informiert ist.
+ */
 void HidKeyboard::typeCodepoint(uint32_t cp) {
     uint8_t mods;
     uint8_t key;
@@ -197,6 +219,13 @@ void HidKeyboard::typeCodepoint(uint32_t cp) {
     pressAndRelease(mods, key);
 }
 
+/**
+ * Callback-Handler für Schreibzugriffe auf die Protocol-Mode-Charakteristik.
+ *
+ * Der Host schreibt hier 0x00 (Boot) oder 0x01 (Report). Der Wert wird
+ * validiert und anschließend gespeichert, damit zukünftige Reports in das
+ * korrekte Format gebracht werden.
+ */
 void HidKeyboard::handleProtocolModeWrite(NimBLECharacteristic* characteristic) {
     std::string value = characteristic->getValue();
     if (value.size() == 1 && (value[0] == 0x00 || value[0] == 0x01)) {
@@ -205,6 +234,14 @@ void HidKeyboard::handleProtocolModeWrite(NimBLECharacteristic* characteristic) 
     }
 }
 
+/**
+ * Aktualisiert die Merker, ob Boot- bzw. Report-Input-Charakteristiken
+ * Benachrichtigungen senden dürfen.
+ *
+ * Der CCCD-Wert (subValue) wird daraufhin untersucht, ob das Notify-Bit
+ * gesetzt ist. Nur wenn dies der Fall ist, werden spätere Reports auf dem
+ * entsprechenden Kanal verschickt.
+ */
 void HidKeyboard::handleSubscription(NimBLECharacteristic* characteristic, uint16_t subValue) {
     const bool notifyEnabled = (subValue & 0x0001);
     if (characteristic == mBootIn) {
@@ -216,6 +253,14 @@ void HidKeyboard::handleSubscription(NimBLECharacteristic* characteristic, uint1
     }
 }
 
+/**
+ * Wird unmittelbar nach erfolgreichem Verbindungsaufbau aufgerufen.
+ *
+ * Nach einem kurzen Delay wird eine Testsequenz bestehend aus "Shift+A" und
+ * Enter gesendet, damit sowohl Boot- als auch Report-Input eine initiale
+ * Aktivität verzeichnen. Das hilft insbesondere bei Hosts, die erst nach dem
+ * ersten Key-Event die Bildschirmanzeige aktivieren.
+ */
 void HidKeyboard::afterConnect() {
     mConnected = true;
     Serial.println("[BLE] Verbunden");
@@ -243,6 +288,10 @@ void HidKeyboard::afterConnect() {
     Serial.printf("[HID] ProtocolMode on connect (may change) = %s\n", mProtocolMode ? "Report(1)" : "Boot(0)");
 }
 
+/**
+ * Rücksetzen aller Statusmerker und Neustart des Advertisings nach
+ * Verbindungsabbruch.
+ */
 void HidKeyboard::afterDisconnect() {
     mConnected = false;
     mSubBootIn = false;
@@ -251,6 +300,18 @@ void HidKeyboard::afterDisconnect() {
     NimBLEDevice::startAdvertising();
 }
 
+/**
+ * Sendet einen Keyboard-Report an die angegebene Charakteristik.
+ *
+ * Für die Boot-Charakteristik besteht der Report aus 8 Bytes (Modifier,
+ * Reserved, sechs Keycodes). Für den Report-Mode wird automatisch die
+ * Report-ID 0x01 vorangestellt, womit der Report insgesamt 9 Bytes umfasst.
+ *
+ * @param characteristic Zielcharakteristik für den Report.
+ * @param tag Debug-Tag für die serielle Ausgabe.
+ * @param mods Modifier-Bits.
+ * @param k1..k6 Bis zu sechs gleichzeitig gedrückte Tasten.
+ */
 void HidKeyboard::sendKeyReportRaw(
     NimBLECharacteristic* characteristic,
     const char* tag,
@@ -302,6 +363,14 @@ void HidKeyboard::sendKeyReportRaw(
         k6);
 }
 
+/**
+ * Öffentliche Helfermethode, die abhängig vom Protokollmodus den passenden
+ * Kanal wählt.
+ *
+ * Ist der Host noch nicht verbunden oder hat keine Benachrichtigungen
+ * aktiviert, wird der Report vorsorglich an beide Charakteristiken gesendet,
+ * damit kein Tastenanschlag verloren geht.
+ */
 void HidKeyboard::sendKeyReport(
     uint8_t mods,
     uint8_t k1,
@@ -330,6 +399,10 @@ void HidKeyboard::sendKeyReport(
     sendKeyReportRaw(mInputReport, "Report*", mods, k1, k2, k3, k4, k5, k6);
 }
 
+/**
+ * Sendet erst einen Tastendruck und anschließend – nach kurzen Delays – den
+ * zugehörigen Release-Report.
+ */
 void HidKeyboard::pressAndRelease(uint8_t mods, uint8_t key) {
     sendKeyReport(mods, key);
     delay(8);
@@ -337,6 +410,12 @@ void HidKeyboard::pressAndRelease(uint8_t mods, uint8_t key) {
     delay(5);
 }
 
+/**
+ * Konvertiert einen Codepoint in das deutsche HID-Layout.
+ *
+ * Neben den Standard-ASCII-Zeichen werden auch Umlaute und Sonderzeichen
+ * behandelt. Modifier-Bits (Shift/AltGr) werden nach Bedarf gesetzt.
+ */
 bool HidKeyboard::cpToHid_DE(uint32_t cp, uint8_t& mods, uint8_t& key) {
     mods = 0;
     if (cp == '\n' || cp == '\r') { key = HID_KEY_ENTER; return true; }

--- a/Src/Esp32NMCI/src/HidKeyboard.h
+++ b/Src/Esp32NMCI/src/HidKeyboard.h
@@ -9,68 +9,121 @@ class HidKeyboardInputSubscribeCallbacks;
 class HidKeyboardServerCallbacks;
 
 /**
- * @brief Verwaltet alle BLE-HID-Funktionen für das virtuelle Keyboard.
+ * @brief Verwaltet den kompletten BLE-HID-Stack für das virtuelle Keyboard.
+ *
+ * Die Klasse kapselt sowohl das Anlegen der notwendigen Services und
+ * Charakteristiken als auch das Erzeugen der Tastatur-Reports. Sie dient somit
+ * als zentrale Abstraktion, um Unicode-Codepoints in HID-Events zu übersetzen
+ * und zuverlässig an einen verbundenen BLE-Host zu übertragen.
  */
 class HidKeyboard {
 public:
-	/**
-	 * @brief Konstruktor initialisiert alle Pointer und Statusvariablen.
-	 */
-	HidKeyboard();
+        /**
+         * @brief Konstruktor initialisiert alle Pointer und Statusvariablen.
+         *
+         * Die Callback-Objekte werden hier erstellt, so dass sie während der
+         * gesamten Lebensdauer der Klasse verfügbar sind.
+         */
+        HidKeyboard();
 
-	/**
-	 * @brief Destruktor sorgt für die Freigabe der Callback-Objekte.
-	 */
-	~HidKeyboard();
+        /**
+         * @brief Destruktor sorgt für die Freigabe der Callback-Objekte.
+         *
+         * Durch die Verwendung von smarten Zeigern ist hier keine zusätzliche
+         * Logik notwendig, dennoch dokumentiert die Methode die Intention.
+         */
+        ~HidKeyboard();
 
-	/**
-	 * @brief Initialisiert NimBLE, richtet den HID-Service ein und startet Advertising.
-	 */
-	void begin();
+        /**
+         * @brief Initialisiert NimBLE, richtet den HID-Service ein und startet Advertising.
+         *
+         * Neben dem HID-Service werden auch die obligatorischen
+         * Device-Information-Charakteristiken sowie die Werbeparameter
+         * konfiguriert. Die Methode muss einmalig in setup() aufgerufen werden.
+         */
+        void begin();
 
-	/**
-	 * @brief Gibt zurück, ob aktuell ein zentraler BLE-Client verbunden ist.
-	 */
-	bool isConnected() const;
+        /**
+         * @brief Gibt zurück, ob aktuell ein zentraler BLE-Client verbunden ist.
+         *
+         * @return true, wenn ein Host gekoppelt ist; andernfalls false.
+         */
+        bool isConnected() const;
 
-	/**
-	 * @brief Konvertiert einen Unicode-Codepoint und sendet ihn als Tastendruck.
-	 *
-	 * Für nicht unterstützte Zeichen werden Diagnosemeldungen im Seriellen Monitor ausgegeben.
-	 */
-	void typeCodepoint(uint32_t cp);
+        /**
+         * @brief Konvertiert einen Unicode-Codepoint und sendet ihn als Tastendruck.
+         *
+         * Der Codepoint wird gegen das deutsche Tastaturlayout abgebildet und
+         * anschließend als Press/Release-Sequenz gesendet. Für nicht
+         * unterstützte Zeichen werden Diagnosemeldungen im seriellen Monitor
+         * ausgegeben.
+         *
+         * @param cp Unicode-Codepoint (UTF-32) des zu sendenden Zeichens.
+         */
+        void typeCodepoint(uint32_t cp);
 
 private:
 	friend class HidKeyboardProtocolModeCallbacks;
 	friend class HidKeyboardInputSubscribeCallbacks;
 	friend class HidKeyboardServerCallbacks;
 
-	/**
-	 * @brief Verarbeitet Schreibzugriffe auf die Protocol-Mode-Charakteristik.
-	 */
-	void handleProtocolModeWrite(NimBLECharacteristic* characteristic);
+        /**
+         * @brief Verarbeitet Schreibzugriffe auf die Protocol-Mode-Charakteristik.
+         *
+         * Aktualisiert den internen Status, sobald der Host zwischen Boot- und
+         * Report-Modus wechselt.
+         *
+         * @param characteristic Charakteristik, die den Schreibzugriff
+         *        ausgelöst hat.
+         */
+        void handleProtocolModeWrite(NimBLECharacteristic* characteristic);
 
-	/**
-	 * @brief Aktualisiert den Subskriptionsstatus für Boot- und Report-Input.
-	 */
-	void handleSubscription(NimBLECharacteristic* characteristic, uint16_t subValue);
+        /**
+         * @brief Aktualisiert den Subskriptionsstatus für Boot- und Report-Input.
+         *
+         * BLE-Hosts können unabhängig voneinander die Benachrichtigungen der
+         * Boot- und der Report-Charakteristik abonnieren. Diese Methode merkt
+         * sich, welche Variante aktiv ist.
+         *
+         * @param characteristic Charakteristik, deren Subskription sich
+         *        geändert hat.
+         * @param subValue Neuer CCCD-Wert aus dem onSubscribe-Callback.
+         */
+        void handleSubscription(NimBLECharacteristic* characteristic, uint16_t subValue);
 
-	/**
-	 * @brief Bereitet das Gerät nach erfolgreichem Verbindungsaufbau vor.
-	 */
-	void afterConnect();
+        /**
+         * @brief Bereitet das Gerät nach erfolgreichem Verbindungsaufbau vor.
+         *
+         * Hier werden Statusvariablen gesetzt und zur Verbindung ein kurzer
+         * Funktionstest (Shift+A, Enter) an den Host gesendet.
+         */
+        void afterConnect();
 
-	/**
-	 * @brief Setzt den Status nach einem Verbindungsabbruch zurück und startet Advertising.
-	 */
-	void afterDisconnect();
+        /**
+         * @brief Setzt den Status nach einem Verbindungsabbruch zurück und startet Advertising.
+         */
+        void afterDisconnect();
 
-	/**
-	 * @brief Sendet einen Rohreport an die angegebene Charakteristik.
-	 */
-	void sendKeyReportRaw(
-		NimBLECharacteristic* characteristic,
-		const char* tag,
+        /**
+         * @brief Sendet einen Rohreport an die angegebene Charakteristik.
+         *
+         * Die Methode bereitet abhängig vom Ziel (Boot- oder Report-Charakteristik)
+         * das passende Datenlayout auf, ergänzt ggf. die Report-ID und stößt
+         * anschließend die BLE-Benachrichtigung an.
+         *
+         * @param characteristic Zielcharakteristik (Boot- oder Report-Input).
+         * @param tag Menschlich lesbares Tag für das Debug-Log.
+         * @param mods Aktive Modifier-Bits.
+         * @param k1 Erster Keycode.
+         * @param k2 Zweiter Keycode.
+         * @param k3 Dritter Keycode.
+         * @param k4 Vierter Keycode.
+         * @param k5 Fünfter Keycode.
+         * @param k6 Sechster Keycode.
+         */
+        void sendKeyReportRaw(
+                NimBLECharacteristic* characteristic,
+                const char* tag,
 		uint8_t mods,
 		uint8_t k1 = 0,
 		uint8_t k2 = 0,
@@ -79,37 +132,68 @@ private:
 		uint8_t k5 = 0,
 		uint8_t k6 = 0);
 
-	/**
-	 * @brief Sendet einen Report unter Berücksichtigung des aktiven Protokolls.
-	 */
-	void sendKeyReport(
-		uint8_t mods,
-		uint8_t k1 = 0,
+        /**
+         * @brief Sendet einen Report unter Berücksichtigung des aktiven Protokolls.
+         *
+         * Abhängig davon, ob der Host Boot- oder Report-Mode aktiviert hat, wird
+         * die passende Charakteristik verwendet. Falls keine aktive
+         * Subskription vorliegt, werden beide Kanäle bedient, um die
+         * Kompatibilität zu maximieren.
+         *
+         * @param mods Aktive Modifier-Bits.
+         * @param k1 Erster Keycode.
+         * @param k2 Zweiter Keycode.
+         * @param k3 Dritter Keycode.
+         * @param k4 Vierter Keycode.
+         * @param k5 Fünfter Keycode.
+         * @param k6 Sechster Keycode.
+         */
+        void sendKeyReport(
+                uint8_t mods,
+                uint8_t k1 = 0,
 		uint8_t k2 = 0,
 		uint8_t k3 = 0,
 		uint8_t k4 = 0,
 		uint8_t k5 = 0,
 		uint8_t k6 = 0);
 
-	/**
-	 * @brief Sendet einen Tastendruck mit anschließendem Release.
-	 */
-	void pressAndRelease(uint8_t mods, uint8_t key);
+        /**
+         * @brief Sendet einen Tastendruck mit anschließendem Release.
+         *
+         * @param mods Modifier-Bits des Tastendrucks.
+         * @param key Keycode des Zeichens.
+         */
+        void pressAndRelease(uint8_t mods, uint8_t key);
 
-	/**
-	 * @brief Wandelt einen Codepoint ins deutsche HID-Layout um.
-	 */
-	bool cpToHid_DE(uint32_t cp, uint8_t& mods, uint8_t& key);
+        /**
+         * @brief Wandelt einen Codepoint ins deutsche HID-Layout um.
+         *
+         * @param cp Eingangs-Codepoint.
+         * @param mods Referenz auf die zu setzenden Modifier-Bits.
+         * @param key Referenz auf den resultierenden HID-Keycode.
+         * @return true, wenn eine Zuordnung existiert; andernfalls false.
+         */
+        bool cpToHid_DE(uint32_t cp, uint8_t& mods, uint8_t& key);
 
-	NimBLECharacteristic* mInputReport;
-	NimBLECharacteristic* mBootIn;
-	NimBLEAdvertising* mAdv;
-	volatile bool mConnected;
-	uint8_t mProtocolMode;
-	volatile bool mSubBootIn;
-	volatile bool mSubReport;
-	std::unique_ptr<HidKeyboardProtocolModeCallbacks> mProtoCb;
-	std::unique_ptr<HidKeyboardInputSubscribeCallbacks> mSubCb;
-	std::unique_ptr<HidKeyboardServerCallbacks> mServerCb;
+        /** Zeiger auf die Report-Mode-Input-Charakteristik. */
+        NimBLECharacteristic* mInputReport;
+        /** Zeiger auf die Boot-Mode-Input-Charakteristik. */
+        NimBLECharacteristic* mBootIn;
+        /** Handle für das Advertising-Objekt von NimBLE. */
+        NimBLEAdvertising* mAdv;
+        /** Verbindungstatus, wird in den Server-Callbacks aktualisiert. */
+        volatile bool mConnected;
+        /** Aktueller Protokollmodus (0 = Boot, 1 = Report). */
+        uint8_t mProtocolMode;
+        /** Merker, ob der Host Boot-Reports abonniert hat. */
+        volatile bool mSubBootIn;
+        /** Merker, ob der Host Report-Mode abonniert hat. */
+        volatile bool mSubReport;
+        /** Callback für Schreibzugriffe auf den Protocol-Mode. */
+        std::unique_ptr<HidKeyboardProtocolModeCallbacks> mProtoCb;
+        /** Callback für Subskriptionen der Input-Reports. */
+        std::unique_ptr<HidKeyboardInputSubscribeCallbacks> mSubCb;
+        /** Callback für Connect/Disconnect-Ereignisse. */
+        std::unique_ptr<HidKeyboardServerCallbacks> mServerCb;
 };
 


### PR DESCRIPTION
## Summary
- add detailed documentation comments to `HidKeyboard` methods and member variables for easier comprehension
- explain the report-handling workflow in the implementation, including the Report-ID handling that matches the defined report map

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d69792963883238f236c5b548c893e