### PR TITLE
Fix LoggingBleKeyboard NimBLE override signatures

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -115,6 +115,21 @@ public:
         using BleKeyboard::BleKeyboard;
 
 protected:
+#if defined(USE_NIMBLE)
+        void onConnect(BLEServer* server, NimBLEConnInfo& connInfo) override
+        {
+                BleKeyboard::onConnect(server, connInfo);
+                Logger::LogInfo(F("[BLE] Verbindung hergestellt."));
+        }
+
+        void onDisconnect(BLEServer* server, NimBLEConnInfo& connInfo, int reason) override
+        {
+                BleKeyboard::onDisconnect(server, connInfo, reason);
+                Logger::logf(Logger::Level::Info,
+                             "[BLE] Verbindung getrennt (Grund: %d).\n",
+                             reason);
+        }
+#else
         void onConnect(BLEServer* server) override
         {
                 BleKeyboard::onConnect(server);
@@ -126,6 +141,7 @@ protected:
                 BleKeyboard::onDisconnect(server);
                 Logger::LogInfo(F("[BLE] Verbindung getrennt."));
         }
+#endif
 };
 
 /**


### PR DESCRIPTION
## Summary
- update LoggingBleKeyboard to use the correct NimBLE callback signatures when USE_NIMBLE is enabled
- retain the classic BLE callbacks for builds without NimBLE and add disconnect reason logging

## Testing
- not run (hardware-specific build)


------
https://chatgpt.com/codex/tasks/task_e_68d6f4f960248323bd7a27f798a77c30