### PR TITLE
Restart BLE advertising after disconnect

### DIFF
--- a/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/0.3.2/ESP32-BLE-Keyboard/BleKeyboard.cpp
+++ b/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/0.3.2/ESP32-BLE-Keyboard/BleKeyboard.cpp
@@ -542,14 +542,16 @@ void BleKeyboard::onDisconnect(BLEServer * pServer) {
 
 #if !defined(USE_NIMBLE)
 
-	BLE2902* desc = (BLE2902*)this->inputKeyboard->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
-	desc->setNotifications(false);
-	desc = (BLE2902*)this->inputMediaKeys->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
-	desc->setNotifications(false);
-
-	advertising->start();
+        BLE2902* desc = (BLE2902*)this->inputKeyboard->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
+        desc->setNotifications(false);
+        desc = (BLE2902*)this->inputMediaKeys->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
+        desc->setNotifications(false);
 
 #endif // !USE_NIMBLE
+
+        if (advertising) {
+                advertising->start();
+        }
 }
 
 

--- a/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/BleKeyboard.cpp
+++ b/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/BleKeyboard.cpp
@@ -523,9 +523,11 @@ void BleKeyboard::onDisconnect(BLEServer* pServer) {
   desc = (BLE2902*)this->inputMediaKeys->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
   desc->setNotifications(false);
 
-  advertising->start();
-
 #endif // !USE_NIMBLE
+
+  if (advertising) {
+    advertising->start();
+  }
 }
 
 void BleKeyboard::onWrite(BLECharacteristic* me) {


### PR DESCRIPTION
## Summary
- restart BLE advertising when a connection drops so the HID keyboard becomes available for reconnection immediately
- apply the same change to the vendored 0.3.2 library copy to keep behaviour consistent

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6f8e7024c83238d2fb15a1a6dd606