### PR TITLE
Restart BLE advertising after disconnect

### DIFF
--- a/Src/Esp32NMCI/src/Ble/LoggingBleKeyboard.cpp
+++ b/Src/Esp32NMCI/src/Ble/LoggingBleKeyboard.cpp
@@ -1,3 +1,43 @@
 #include "LoggingBleKeyboard.h"
 
-// nothing yet
+#if defined(USE_NIMBLE)
+#include <NimBLEAdvertising.h>
+#endif
+
+void LoggingBleKeyboard::restartAdvertisingIfNecessary()
+{
+#if defined(USE_NIMBLE)
+    NimBLEAdvertising* advertising = BLEDevice::getAdvertising();
+
+    if (advertising == nullptr)
+    {
+        Logger::LogWarn(F("[BLE] Kein Advertising-Objekt verfügbar; versuche Neustart."));
+        if (BLEDevice::startAdvertising())
+        {
+            Logger::LogInfo(F("[BLE] Advertising im Fallback erfolgreich gestartet."));
+        }
+        else
+        {
+            Logger::LogError(F("[BLE] Advertising konnte im Fallback nicht gestartet werden."));
+        }
+        return;
+    }
+
+    if (advertising->isAdvertising())
+    {
+        Logger::LogDebug(F("[BLE] Advertising läuft bereits; kein Neustart erforderlich."));
+        return;
+    }
+
+    if (advertising->start())
+    {
+        Logger::LogInfo(F("[BLE] Advertising nach Trennung neu gestartet."));
+    }
+    else
+    {
+        Logger::LogError(F("[BLE] Advertising konnte nach Trennung nicht gestartet werden."));
+    }
+#else
+    // Klassischer BLE-Stack: das Basismodul übernimmt den Neustart des Advertisings.
+#endif
+}

--- a/Src/Esp32NMCI/src/Ble/LoggingBleKeyboard.h
+++ b/Src/Esp32NMCI/src/Ble/LoggingBleKeyboard.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <NimBLEDevice.h> // 2.3.6
-#include <BleKeyboard.h> // Hinweis: Manuell gepatched für NimBLE 2.3.6!
+#include <BleKeyboard.h> // Hinweis: Manuell gepatched fÃ¼r NimBLE 2.3.6!
 #include "../Presentation/DisplayManager.h"
 #include "../Logger/Logger.h"
 
 
 /**
- * @brief Spezialisierte Tastaturemulation mit zusätzlichen Logmeldungen.
+ * @brief Spezialisierte Tastaturemulation mit zusÃ¤tzlichen Logmeldungen.
  */
 class LoggingBleKeyboard final : public BleKeyboard
 {
@@ -28,6 +28,7 @@ protected:
         Logger::logf(Logger::Level::Info,
             "[BLE] Verbindung getrennt (Grund: %d).\n",
             reason);
+        restartAdvertisingIfNecessary();
     }
 #else
     void onConnect(BLEServer* server) override
@@ -40,6 +41,10 @@ protected:
     {
         BleKeyboard::onDisconnect(server);
         Logger::LogInfo(F("[BLE] Verbindung getrennt."));
+        restartAdvertisingIfNecessary();
     }
 #endif
+
+private:
+    void restartAdvertisingIfNecessary();
 };


### PR DESCRIPTION
## Summary
- restart BLE advertising from LoggingBleKeyboard after a disconnect when using NimBLE
- add detailed logging and fallback handling for advertising restarts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6fa7d9d1c8323aaa5ccc235bb9146