### PR TITLE
Add BLE status indicator overlay to display

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -183,6 +183,7 @@ void setup()
 
 	displayManager.begin(DisplayManager::Orientation::UsbLeft);
 	Logger::setDisplayManager(&displayManager);
+	gbleKeyboard.setDisplayManager(&displayManager);
 
 	cardReaderManager.setNewDataCallback(OnNewData);
 	cardReaderManager.begin();

--- a/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.h
+++ b/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.h
@@ -14,12 +14,26 @@ class BleKeyboardCallback final : public BleKeyboard
 public:
     using BleKeyboard::BleKeyboard;
 
+    void setDisplayManager(DisplayManager* manager)
+    {
+        displayManager = manager;
+
+        if (displayManager != nullptr)
+        {
+            displayManager->setBleConnectionState(isConnected());
+        }
+    }
+
 protected:
 #if defined(USE_NIMBLE)
     void onConnect(BLEServer* server, NimBLEConnInfo& connInfo) override
     {
         BleKeyboard::onConnect(server, connInfo);
         Logger::LogInfo(F("[BLE] Verbindung hergestellt."));
+        if (displayManager != nullptr)
+        {
+            displayManager->setBleConnectionState(true);
+        }
     }
 
     void onDisconnect(BLEServer* server, NimBLEConnInfo& connInfo, int reason) override
@@ -28,6 +42,10 @@ protected:
         Logger::logf(Logger::Level::Info,
             "[BLE] Verbindung getrennt (Grund: %d).\n",
             reason);
+        if (displayManager != nullptr)
+        {
+            displayManager->setBleConnectionState(false);
+        }
         restartAdvertisingIfNecessary();
     }
 #else
@@ -35,16 +53,25 @@ protected:
     {
         BleKeyboard::onConnect(server);
         Logger::LogInfo(F("[BLE] Verbindung hergestellt."));
+        if (displayManager != nullptr)
+        {
+            displayManager->setBleConnectionState(true);
+        }
     }
 
     void onDisconnect(BLEServer* server) override
     {
         BleKeyboard::onDisconnect(server);
         Logger::LogInfo(F("[BLE] Verbindung getrennt."));
+        if (displayManager != nullptr)
+        {
+            displayManager->setBleConnectionState(false);
+        }
         restartAdvertisingIfNecessary();
     }
 #endif
 
 private:
     void restartAdvertisingIfNecessary();
+    DisplayManager* displayManager = nullptr;
 };

--- a/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
+++ b/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
@@ -1,13 +1,23 @@
 #include <Arduino.h>
 #include <TFT_eSPI.h>
 #include <SPI.h>
+#include <algorithm>
 #include "DisplayManager.h"
 #include "../Logger/Logger.h"
 #include "../config.h"
 
+namespace
+{
+constexpr int16_t kTextMargin = 10;
+constexpr int16_t kOverlayEdgeMargin = 4;
+constexpr int16_t kOverlayIconSpacing = 4;
+constexpr int16_t kOverlayTextSpacing = 6;
+constexpr int16_t kBleIndicatorSize = 10;
+}
+
 void DisplayManager::begin(Orientation orientation)
 {
-	tft.init();
+        tft.init();
 
 	// Map the requested physical orientation to the library's rotation indices.
 	uint8_t rotation = 1;
@@ -28,27 +38,55 @@ void DisplayManager::begin(Orientation orientation)
 
 #ifdef TFT_BL
 	pinMode(TFT_BL, OUTPUT);
-	digitalWrite(TFT_BL, TFT_BACKLIGHT_ON);
+        digitalWrite(TFT_BL, TFT_BACKLIGHT_ON);
 #endif
 
-	showMessage(VERSION_TEXT, false);
+        overlays.clear();
+        lastRenderedTopOverlayAreaHeight = 0;
+        lastRenderedBottomOverlayAreaHeight = 0;
+        bleOverlayIndex = registerOverlay(OverlayPlacement::Top,
+                                          kBleIndicatorSize,
+                                          kBleIndicatorSize,
+                                          [](TFT_eSPI& tftDisplay, int16_t x, int16_t y) {
+                                                  tftDisplay.fillRect(x, y, kBleIndicatorSize, kBleIndicatorSize, TFT_BLUE);
+                                          });
+        bleConnectionActive = false;
+
+        showMessage(VERSION_TEXT, false);
 }
 
 void DisplayManager::renderSingleMessage(const String& message, uint16_t textColor)
 {
-	clearScreen();
+        clearScreen();
 
-	tft.setTextDatum(MC_DATUM); // Mitte zentriert
-	tft.setTextColor(textColor, TFT_BLACK);
+        tft.setTextDatum(MC_DATUM); // Mitte zentriert
+        tft.setTextColor(textColor, currentBackgroundColor);
 
-	// Maximale Displaygröße
-	int maxWidth = tft.width() - 10;   // etwas Rand lassen
-	int maxHeight = tft.height() - 10;
+        const uint16_t topArea = calculateOverlayAreaHeight(OverlayPlacement::Top);
+        const uint16_t bottomArea = calculateOverlayAreaHeight(OverlayPlacement::Bottom);
+        const int16_t textAreaHeight = tft.height() - static_cast<int16_t>(topArea + bottomArea);
+        if (textAreaHeight <= 0)
+        {
+                renderOverlays();
+                return;
+        }
 
-	int bestSize = 1;
-	for (int size = 1; size <= 8; ++size) // 1 bis 7 sind vernünftig
-	{
-		tft.setTextSize(size);
+        const int16_t textAreaTop = static_cast<int16_t>(topArea);
+        const int16_t textAreaCenterY = textAreaTop + (textAreaHeight / 2);
+
+        // Maximale Displaygröße
+        int maxWidth = tft.width() - kTextMargin;   // etwas Rand lassen
+        int maxHeight = textAreaHeight - kTextMargin;
+
+        if (maxHeight < 8)
+        {
+                maxHeight = 8;
+        }
+
+        int bestSize = 1;
+        for (int size = 1; size <= 8; ++size) // 1 bis 7 sind vernünftig
+        {
+                tft.setTextSize(size);
 		int16_t w = tft.textWidth(message);
 		int16_t h = 8 * size;  // Standardhöhe der Schrift bei Größe 1 = 8px
 
@@ -56,22 +94,23 @@ void DisplayManager::renderSingleMessage(const String& message, uint16_t textCol
 		{
 			break;  // letzte gültige Größe war bestSize
 		}
-		bestSize = size;
-	}
+                bestSize = size;
+        }
 
-	tft.setTextSize(bestSize);
-	tft.drawString(message, tft.width() / 2, tft.height() / 2);
+        tft.setTextSize(bestSize);
+        tft.drawString(message, tft.width() / 2, textAreaCenterY);
 
-	// drawStatusOverlay();  // Sprite neu zeichnen
+        renderOverlays();
 }
 
 void DisplayManager::showError(const String& message, bool withOverlay)
 {
         (void)withOverlay;
 
-        tft.fillScreen(TFT_RED);
+        currentBackgroundColor = TFT_RED;
+        tft.fillScreen(currentBackgroundColor);
         tft.setTextDatum(TL_DATUM);
-        tft.setTextColor(TFT_YELLOW, TFT_RED);
+        tft.setTextColor(TFT_YELLOW, currentBackgroundColor);
 
         constexpr uint8_t maxLines = 4;
         constexpr size_t maxCharactersPerLine = 12;
@@ -100,6 +139,7 @@ void DisplayManager::showError(const String& message, bool withOverlay)
                 lastMessageWasList = false;
                 lastMessageValid = false;
                 lastMessageCurrentlyGreen = false;
+                renderOverlays();
                 return;
         }
 
@@ -121,9 +161,23 @@ void DisplayManager::showError(const String& message, bool withOverlay)
                 startIndex = endIndex;
         }
 
+        const uint16_t topArea = calculateOverlayAreaHeight(OverlayPlacement::Top);
+        const uint16_t bottomArea = calculateOverlayAreaHeight(OverlayPlacement::Bottom);
+        const int16_t textAreaHeight = tft.height() - static_cast<int16_t>(topArea + bottomArea);
+
+        if (textAreaHeight <= 0)
+        {
+                renderOverlays();
+                return;
+        }
+
         const int16_t margin = 10;
         const int16_t availableWidth = tft.width() - (margin * 2);
-        const int16_t availableHeight = tft.height() - (margin * 2);
+        int16_t availableHeight = textAreaHeight - (margin * 2);
+        if (availableHeight < 8)
+        {
+                availableHeight = 8;
+        }
 
         int bestSize = 1;
         for (int size = 1; size <= 8; ++size)
@@ -159,7 +213,8 @@ void DisplayManager::showError(const String& message, bool withOverlay)
 
         const int16_t lineHeight = 8 * bestSize;
         const int16_t totalVisibleHeight = lineHeight * maxLines;
-        const int16_t startY = (tft.height() - totalVisibleHeight) / 2;
+        const int16_t textAreaTop = static_cast<int16_t>(topArea);
+        const int16_t startY = textAreaTop + ((textAreaHeight - totalVisibleHeight) / 2);
 
         for (size_t i = 0; i < lines.size(); ++i)
         {
@@ -170,11 +225,13 @@ void DisplayManager::showError(const String& message, bool withOverlay)
         lastMessageWasList = false;
         lastMessageValid = false;
         lastMessageCurrentlyGreen = false;
+
+        renderOverlays();
 }
 
 void DisplayManager::showMessage(const String& message, bool withOverlay)
 {
-	renderSingleMessage(message, TFT_GREEN);
+        renderSingleMessage(message, TFT_GREEN);
 
 	std::vector<String> displayedLines;
 	displayedLines.push_back(message);
@@ -183,23 +240,25 @@ void DisplayManager::showMessage(const String& message, bool withOverlay)
 
 void DisplayManager::clearScreen() {
 
-	tft.fillScreen(TFT_BLACK);
+        currentBackgroundColor = TFT_BLACK;
+        tft.fillScreen(currentBackgroundColor);
 }
 
 void DisplayManager::renderMultipleMessages(const std::vector<String>& messages, uint16_t textColor)
 {
-	clearScreen();
+        clearScreen();
 
-	tft.setTextDatum(MC_DATUM);
-	tft.setTextColor(textColor, TFT_BLACK);
+        tft.setTextDatum(MC_DATUM);
+        tft.setTextColor(textColor, currentBackgroundColor);
 
-	if (messages.empty())
-	{
-		return;
-	}
+        if (messages.empty())
+        {
+                renderOverlays();
+                return;
+        }
 
-	constexpr uint8_t maxLines = 3;
-	constexpr size_t maxCharactersPerLine = 12;
+        constexpr uint8_t maxLines = 3;
+        constexpr size_t maxCharactersPerLine = 12;
 	const size_t lineCount = messages.size() < maxLines ? messages.size() : maxLines;
 
 	std::vector<String> truncatedMessages;
@@ -215,23 +274,37 @@ void DisplayManager::renderMultipleMessages(const std::vector<String>& messages,
 		{
 			truncatedMessages.emplace_back(message);
 		}
-	}
+        }
 
-	const int16_t margin = 10;
-	const int16_t availableWidth = tft.width() - (margin * 2);
-	const int16_t availableHeight = tft.height() - (margin * 2);
+        const uint16_t topArea = calculateOverlayAreaHeight(OverlayPlacement::Top);
+        const uint16_t bottomArea = calculateOverlayAreaHeight(OverlayPlacement::Bottom);
+        const int16_t textAreaHeight = tft.height() - static_cast<int16_t>(topArea + bottomArea);
 
-	int bestSize = 1;
-	for (int size = 1; size <= 8; ++size)
-	{
-		tft.setTextSize(size);
-		const int16_t lineHeight = 8 * size;
-		const int16_t totalHeight = lineHeight * maxLines;
+        if (textAreaHeight <= 0)
+        {
+                renderOverlays();
+                return;
+        }
 
-		if (totalHeight > availableHeight)
-		{
-			break;
-		}
+        const int16_t margin = 10;
+        const int16_t availableWidth = tft.width() - (margin * 2);
+        int16_t availableHeight = textAreaHeight - (margin * 2);
+        if (availableHeight < 8)
+        {
+                availableHeight = 8;
+        }
+
+        int bestSize = 1;
+        for (int size = 1; size <= 8; ++size)
+        {
+                tft.setTextSize(size);
+                const int16_t lineHeight = 8 * size;
+                const int16_t totalHeight = lineHeight * maxLines;
+
+                if (totalHeight > availableHeight)
+                {
+                        break;
+                }
 
 		bool fits = true;
 		for (size_t i = 0; i < lineCount; ++i)
@@ -251,15 +324,18 @@ void DisplayManager::renderMultipleMessages(const std::vector<String>& messages,
 		bestSize = size;
 	}
 
-	tft.setTextSize(bestSize);
-	const int16_t lineHeight = 8 * bestSize;
-	const int16_t totalVisibleHeight = lineHeight * static_cast<int16_t>(lineCount);
-	const int16_t startY = (tft.height() - totalVisibleHeight) / 2 + (lineHeight / 2);
+        tft.setTextSize(bestSize);
+        const int16_t lineHeight = 8 * bestSize;
+        const int16_t totalVisibleHeight = lineHeight * static_cast<int16_t>(lineCount);
+        const int16_t textAreaTop = static_cast<int16_t>(topArea);
+        const int16_t startY = textAreaTop + ((textAreaHeight - totalVisibleHeight) / 2) + (lineHeight / 2);
 
-	for (size_t i = 0; i < lineCount; ++i)
-	{
-		tft.drawString(truncatedMessages[i], tft.width() / 2, startY + (lineHeight * static_cast<int16_t>(i)));
-	}
+        for (size_t i = 0; i < lineCount; ++i)
+        {
+                tft.drawString(truncatedMessages[i], tft.width() / 2, startY + (lineHeight * static_cast<int16_t>(i)));
+        }
+
+        renderOverlays();
 }
 
 void DisplayManager::showMessage(const std::vector<String>& messages)
@@ -280,17 +356,37 @@ void DisplayManager::showMessage(const std::vector<String>& messages)
 
 void DisplayManager::cacheMessageToRemember(const std::vector<String>& messages, bool isList)
 {
-	lastDisplayedLines = messages;
-	lastMessageWasList = isList;
-	lastMessageValid = !messages.empty();
-	lastMessageCurrentlyGreen = lastMessageValid;
-	lastMessageTimestamp = millis();
+        lastDisplayedLines = messages;
+        lastMessageWasList = isList;
+        lastMessageValid = !messages.empty();
+        lastMessageCurrentlyGreen = lastMessageValid;
+        lastMessageTimestamp = millis();
+}
+
+void DisplayManager::redrawCachedMessage()
+{
+        if (!lastMessageValid)
+        {
+                renderOverlays();
+                return;
+        }
+
+        const uint16_t textColor = lastMessageCurrentlyGreen ? TFT_GREEN : TFT_DARKGREY;
+
+        if (lastMessageWasList)
+        {
+                renderMultipleMessages(lastDisplayedLines, textColor);
+        }
+        else if (!lastDisplayedLines.empty())
+        {
+                renderSingleMessage(lastDisplayedLines.front(), textColor);
+        }
 }
 
 /*
-	Prüft ob die Zeit abgelaufen ist um das Display auszugrauen.
+        Prüft ob die Zeit abgelaufen ist um das Display auszugrauen.
 
-	@see kDisplayManager_TimeToFadeOutDisplay Konfiguration des Delay bis zum Ausgrauen
+        @see kDisplayManager_TimeToFadeOutDisplay Konfiguration des Delay bis zum Ausgrauen
 */
 void DisplayManager::update()
 {
@@ -314,5 +410,125 @@ void DisplayManager::update()
 		renderSingleMessage(lastDisplayedLines.front(), TFT_DARKGREY);
 	}
 
-	lastMessageCurrentlyGreen = false;
+        lastMessageCurrentlyGreen = false;
+}
+
+size_t DisplayManager::registerOverlay(OverlayPlacement placement, uint16_t width, uint16_t height, OverlayDrawFunction drawFunction)
+{
+        overlays.push_back({placement, width, height, false, drawFunction});
+        return overlays.size() - 1U;
+}
+
+void DisplayManager::setOverlayVisibility(size_t index, bool visible)
+{
+        if (index >= overlays.size())
+        {
+                return;
+        }
+
+        OverlayItem& overlay = overlays[index];
+        if (overlay.visible == visible)
+        {
+                return;
+        }
+
+        overlay.visible = visible;
+        redrawCachedMessage();
+}
+
+uint16_t DisplayManager::getMaxOverlayHeight(OverlayPlacement placement) const
+{
+        uint16_t maxHeight = 0;
+        for (const auto& overlay : overlays)
+        {
+                if (overlay.placement == placement && overlay.visible)
+                {
+                        maxHeight = std::max<uint16_t>(maxHeight, overlay.height);
+                }
+        }
+        return maxHeight;
+}
+
+uint16_t DisplayManager::calculateOverlayAreaHeight(OverlayPlacement placement) const
+{
+        const uint16_t maxHeight = getMaxOverlayHeight(placement);
+        if (maxHeight == 0)
+        {
+                return 0;
+        }
+
+        return static_cast<uint16_t>(kOverlayEdgeMargin + maxHeight + kOverlayTextSpacing);
+}
+
+void DisplayManager::renderOverlayRow(OverlayPlacement placement)
+{
+        uint16_t& lastHeight = (placement == OverlayPlacement::Top) ? lastRenderedTopOverlayAreaHeight : lastRenderedBottomOverlayAreaHeight;
+        const uint16_t areaHeight = calculateOverlayAreaHeight(placement);
+        const uint16_t clearHeight = std::max(areaHeight, lastHeight);
+
+        if (clearHeight > 0)
+        {
+                const int16_t clearY = (placement == OverlayPlacement::Top) ? 0 : tft.height() - static_cast<int16_t>(clearHeight);
+                tft.fillRect(0, clearY, tft.width(), clearHeight, currentBackgroundColor);
+        }
+
+        if (areaHeight == 0)
+        {
+                lastHeight = 0;
+                return;
+        }
+
+        int16_t x = kOverlayEdgeMargin;
+
+        if (placement == OverlayPlacement::Top)
+        {
+                const int16_t y = kOverlayEdgeMargin;
+                for (const auto& overlay : overlays)
+                {
+                        if (overlay.placement != OverlayPlacement::Top || !overlay.visible || overlay.drawFunction == nullptr)
+                        {
+                                continue;
+                        }
+
+                        overlay.drawFunction(tft, x, y);
+                        x += static_cast<int16_t>(overlay.width) + kOverlayIconSpacing;
+                }
+        }
+        else
+        {
+                for (const auto& overlay : overlays)
+                {
+                        if (overlay.placement != OverlayPlacement::Bottom || !overlay.visible || overlay.drawFunction == nullptr)
+                        {
+                                continue;
+                        }
+
+                        const int16_t y = tft.height() - kOverlayEdgeMargin - static_cast<int16_t>(overlay.height);
+                        overlay.drawFunction(tft, x, y);
+                        x += static_cast<int16_t>(overlay.width) + kOverlayIconSpacing;
+                }
+        }
+
+        lastHeight = areaHeight;
+}
+
+void DisplayManager::renderOverlays()
+{
+        renderOverlayRow(OverlayPlacement::Top);
+        renderOverlayRow(OverlayPlacement::Bottom);
+}
+
+void DisplayManager::setBleConnectionState(bool connected)
+{
+        if (bleConnectionActive == connected)
+        {
+                return;
+        }
+
+        bleConnectionActive = connected;
+
+        if (bleOverlayIndex < overlays.size())
+        {
+                setOverlayVisibility(bleOverlayIndex, connected);
+        }
 }

--- a/Src/Esp32NMCI/src/Presentation/DisplayManager.h
+++ b/Src/Esp32NMCI/src/Presentation/DisplayManager.h
@@ -2,6 +2,7 @@
 #include <TFT_eSPI.h>
 #include <SPI.h>
 #include <stdint.h>
+#include <limits>
 #include <vector>
 
 class DisplayManager
@@ -18,6 +19,7 @@ public:
     void showMessage(const std::vector<String>& messages);
     void showError(const String& message, bool withOverlay = true);
     void update();
+    void setBleConnectionState(bool connected);
 
 private:
     TFT_eSPI tft = TFT_eSPI();
@@ -25,11 +27,42 @@ private:
     void renderSingleMessage(const String& message, uint16_t textColor);
     void renderMultipleMessages(const std::vector<String>& messages, uint16_t textColor);
     void cacheMessageToRemember(const std::vector<String>& messages, bool isList);
+    void redrawCachedMessage();
+    void renderOverlays();
+
+    enum class OverlayPlacement : uint8_t
+    {
+        Top,
+        Bottom,
+    };
+
+    using OverlayDrawFunction = void (*)(TFT_eSPI&, int16_t, int16_t);
+
+    struct OverlayItem
+    {
+        OverlayPlacement placement;
+        uint16_t width;
+        uint16_t height;
+        bool visible;
+        OverlayDrawFunction drawFunction;
+    };
+
+    size_t registerOverlay(OverlayPlacement placement, uint16_t width, uint16_t height, OverlayDrawFunction drawFunction);
+    void setOverlayVisibility(size_t index, bool visible);
+    uint16_t getMaxOverlayHeight(OverlayPlacement placement) const;
+    uint16_t calculateOverlayAreaHeight(OverlayPlacement placement) const;
+    void renderOverlayRow(OverlayPlacement placement);
 
     std::vector<String> lastDisplayedLines;
     bool lastMessageWasList = false;
     bool lastMessageValid = false;
     bool lastMessageCurrentlyGreen = false;
     uint32_t lastMessageTimestamp = 0;
+    std::vector<OverlayItem> overlays;
+    size_t bleOverlayIndex = std::numeric_limits<size_t>::max();
+    bool bleConnectionActive = false;
+    uint16_t lastRenderedTopOverlayAreaHeight = 0;
+    uint16_t lastRenderedBottomOverlayAreaHeight = 0;
+    uint16_t currentBackgroundColor = TFT_BLACK;
 };
 


### PR DESCRIPTION
## Summary
- add a reusable overlay system to the display manager and render a blue BLE indicator square while a connection is active
- adjust the text layout to reserve space for top/bottom overlays and keep them visible even on error screens
- notify the display manager of BLE connection changes via the keyboard callbacks and setup wiring so the indicator tracks the link state

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6fd8c30088323951e53a18c791447