### PR TITLE
Add descriptive headers to Esp32NMCI source files

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -3,6 +3,9 @@
  * File: Esp32NMCI.ino
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Hauptsketch, der Display, Taster, BLE-Tastatur und NFC-Leser
+ *              initialisiert und die komplette Kartenverarbeitungslogik
+ *              orchestriert.
  ***************************************************************************/
 
 /**************************************************************************/

--- a/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.cpp
+++ b/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.cpp
@@ -3,6 +3,8 @@
  * File: BleKeyboardCallback.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Implementiert die Logik zum Neustarten des BLE-Advertisings
+ *              nach Verbindungsabbrüchen und ergänzt Diagnoseausgaben.
  ***************************************************************************/
 
 #include "BleKeyboardCallback.h"

--- a/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.h
+++ b/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.h
@@ -3,6 +3,8 @@
  * File: BleKeyboardCallback.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Deklaration einer erweiterten BLE-Tastatur, die Verbindungs-
+ *              callbacks protokolliert und den Anzeigestatus aktualisiert.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.cpp
+++ b/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.cpp
@@ -3,6 +3,8 @@
  * File: CardPayloadProcessor.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Implementiert das Zerlegen von Nutztexten in maximal fünf
+ *              bereinigte Werte und protokolliert Sonderfälle der Eingabe.
  ***************************************************************************/
 
 #include "CardPayloadProcessor.h"

--- a/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.h
+++ b/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.h
@@ -3,6 +3,8 @@
  * File: CardPayloadProcessor.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Deklaration der Hilfsklasse, die Kartennutzdaten in aufbereitete
+ *              Listenelemente für Anzeige und BLE-Transfer zerlegt.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
@@ -3,6 +3,8 @@
  * File: CardReaderManager.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Enthält die Laufzeitlogik zur Initialisierung des PN532, zum
+ *              Erfassen von Type-2-Tags und zum Weiterreichen der NDEF-Daten.
  ***************************************************************************/
 
 #include "CardReaderManager.h"

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
@@ -3,6 +3,8 @@
  * File: CardReaderManager.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Schnittstellendeklaration des Managers, der den PN532 ansteuert,
+ *              NFC-Tags verarbeitet und Nutzdaten an Callbacks weitergibt.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/CardReader/NdefHelper.cpp
+++ b/Src/Esp32NMCI/src/CardReader/NdefHelper.cpp
@@ -3,6 +3,8 @@
  * File: NdefHelper.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Stellt die Routinen zum Auffinden und Dekodieren von TLV- und
+ *              NDEF-Inhalten bereit, inklusive Ausgabehilfen.
  ***************************************************************************/
 
 #include "NdefHelper.h"

--- a/Src/Esp32NMCI/src/CardReader/NdefHelper.h
+++ b/Src/Esp32NMCI/src/CardReader/NdefHelper.h
@@ -3,6 +3,8 @@
  * File: NdefHelper.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Deklariert Funktionen zum Parsen von TLV- und NDEF-Strukturen
+ *              aus den ausgelesenen NFC-Tag-Daten.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/CardReader/Type2TagReader.cpp
+++ b/Src/Esp32NMCI/src/CardReader/Type2TagReader.cpp
@@ -3,6 +3,8 @@
  * File: Type2TagReader.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Implementiert das Auslesen von Capability-Container und
+ *              Nutzspeicher der Type-2-Tags über den PN532.
  ***************************************************************************/
 
 #include "Type2TagReader.h"

--- a/Src/Esp32NMCI/src/CardReader/Type2TagReader.h
+++ b/Src/Esp32NMCI/src/CardReader/Type2TagReader.h
@@ -3,6 +3,8 @@
  * File: Type2TagReader.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Deklaration eines Readers für MIFARE-Type-2-Tags inklusive
+ *              Auslesen des Capability Containers und des Nutzspeichers.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/Helper/Utf8Decoder.cpp
+++ b/Src/Esp32NMCI/src/Helper/Utf8Decoder.cpp
@@ -3,6 +3,8 @@
  * File: Utf8Decoder.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Liefert die Zustandsmaschine zur UTF-8-Dekodierung für den
+ *              zeichenweisen Empfang von Kartendaten.
  ***************************************************************************/
 
 #include "Utf8Decoder.h"

--- a/Src/Esp32NMCI/src/Helper/Utf8Decoder.h
+++ b/Src/Esp32NMCI/src/Helper/Utf8Decoder.h
@@ -3,6 +3,8 @@
  * File: Utf8Decoder.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Deklaration eines kleinen Zustandsautomaten zum Streamen und
+ *              Dekodieren von UTF-8-Eingabedaten in Unicode-Codepoints.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/Logger/Logger.cpp
+++ b/Src/Esp32NMCI/src/Logger/Logger.cpp
@@ -3,6 +3,8 @@
  * File: Logger.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Implementiert die Ausgabe- und Formatierungsfunktionen des
+ *              Loggers inklusive Serial-Setup und Displaybenachrichtigung.
  ***************************************************************************/
 
 #include "Logger.h"

--- a/Src/Esp32NMCI/src/Logger/Logger.h
+++ b/Src/Esp32NMCI/src/Logger/Logger.h
@@ -3,6 +3,8 @@
  * File: Logger.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Deklariert das Logging-Subsystem mit Anzeigeintegration, das
+ *              formatierte Ausgaben verschiedener Schweregrade bereitstellt.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/Presentation/ButtonManager.cpp
+++ b/Src/Esp32NMCI/src/Presentation/ButtonManager.cpp
@@ -3,6 +3,8 @@
  * File: ButtonManager.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Realisiert das zyklische Einlesen der Taster, erkennt Kurz-
+ *              und Langdrucke und triggert konfigurierte Aktionen.
  ***************************************************************************/
 
 // ButtonManager.cpp

--- a/Src/Esp32NMCI/src/Presentation/ButtonManager.h
+++ b/Src/Esp32NMCI/src/Presentation/ButtonManager.h
@@ -3,6 +3,8 @@
  * File: ButtonManager.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Deklariert die Verwaltung der physischen Taster inklusive
+ *              Entprellung, Zustandsabfrage und Callback-Zuweisung.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
+++ b/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
@@ -3,6 +3,8 @@
  * File: DisplayManager.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Implementiert die Darstellung von Meldungen und Overlays auf
+ *              dem T-Display einschließlich BLE-Status und Fade-Out-Logik.
  ***************************************************************************/
 
 #include <Arduino.h>

--- a/Src/Esp32NMCI/src/Presentation/DisplayManager.h
+++ b/Src/Esp32NMCI/src/Presentation/DisplayManager.h
@@ -3,6 +3,8 @@
  * File: DisplayManager.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Deklariert die Ansteuerung des T-Display-Displays inklusive
+ *              Overlayverwaltung, BLE-Statusanzeige und Nachrichtencache.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/config.h
+++ b/Src/Esp32NMCI/src/config.h
@@ -3,6 +3,8 @@
  * File: config.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
+ * Description: Zentrale Konfigurationswerte für Pins, Geschwindigkeiten und
+ *              Grenzwerte des NFC-Lesers sowie Anzeigeparameter.
  ***************************************************************************/
 
 #pragma once


### PR DESCRIPTION
## Summary
- add concise file-level descriptions to the Esp32NMCI sketch and shared configuration header
- document the BLE, card reader, helper, logger, and presentation modules with descriptive header comments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7cc7c3ed083239b1ff8e82fc76f10