### PR TITLE
Translate Esp32NMCI documentation to English

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -3,9 +3,9 @@
  * File: Esp32NMCI.ino
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Hauptsketch, der Display, Taster, BLE-Tastatur und NFC-Leser
- *              initialisiert und die komplette Kartenverarbeitungslogik
- *              orchestriert.
+ * Description: Main sketch that initializes the display, buttons, BLE keyboard,
+ *              and NFC reader while orchestrating the complete card processing
+ *              workflow.
  ***************************************************************************/
 
 /**************************************************************************/
@@ -14,32 +14,32 @@
   Esp32NMCI.ino
 
   ESP32 T-Display + PN532 (HSU/UART)
-  Erkennung von Type-2-Tag via Capability Container (Page 3),
-  dynamisches Lesen des gesamten User-Memory (ab Page 4),
-  TLV-Parsing, NDEF-Parsing (erster Record) optional Textausgabe.
+  Detection of Type-2 tags via capability container (page 3),
+  dynamic reading of the complete user memory (from page 4 onwards),
+  TLV parsing, NDEF parsing (first record) with optional text output.
 
-  Verkabelung (HSU/UART):
-				ESP32 TX (GPIO 25) → PN532 RX
-				ESP32 RX (GPIO 26) → PN532 TX
-				3,3V Pegel, PN532 auf HSU/UART gestellt
+  Wiring (HSU/UART):
+                                ESP32 TX (GPIO 25) → PN532 RX
+                                ESP32 RX (GPIO 26) → PN532 TX
+                                3.3 V logic level, PN532 configured for HSU/UART
 
-  Serielle Ausgabe: 115200 Baud
+  Serial output: 115200 baud
 */
 /**************************************************************************/
 
-// Ble Handling - Keyboard Emulation
+// BLE handling – keyboard emulation
 #include <NimBLEDevice.h> // 2.3.6
-#include <BleKeyboard.h> // Hinweis: Manuell gepatched für NimBLE 2.3.6!
+#include <BleKeyboard.h> // Manually patched for NimBLE 2.3.6!
 
-// Für T-Disüplay notwendig
+// Required for the T-Display
 #include <SPI.h>
 #include <TFT_eSPI.h>
 
-// Card Reader
+// Card reader
 #include <PN532.h>
 #include <PN532_HSU.h>
 
-// Stuff :-)
+// Miscellaneous helpers :-)
 #include <vector>
 #include <esp_sleep.h>
 
@@ -55,74 +55,74 @@
 #include "src/Helper/Utf8Decoder.h"
 #include "src/Ble/BleKeyboardCallback.h"
 
-// Card Reader
+// Card reader
 
 /**
- * @brief High-Speed-UART-Schnittstelle zum PN532-Modul.
+ * @brief High-speed UART interface to the PN532 module.
  */
 static PN532_HSU pn532hsu(PN532_HSU_PORT);
 
 /**
- * @brief PN532-Instanz zur Kommunikation mit dem NFC-Leser.
+ * @brief PN532 instance used to communicate with the NFC reader.
  */
 static PN532 nfc(pn532hsu);
 
 /**
- * @brief Reader für MIFARE-Type-2-Tags basierend auf dem PN532.
+ * @brief Reader for MIFARE Type 2 tags using the PN532.
  */
 static Type2TagReader tagReader(nfc);
 
 /**
- * @brief Hilfsklasse zum Interpretieren von NDEF-Daten.
+ * @brief Helper class for interpreting NDEF data.
  */
 static NdefHelper ndefHelper;
 
 /**
- * @brief Steuerung der Kartenleser-Logik inklusive Callback-Registrierung.
+ * @brief Coordinates the card reader logic, including callback registration.
  */
 static CardReaderManager cardReaderManager(nfc, tagReader, ndefHelper);
 
 /**
- * @brief Verarbeitet Kartendaten zu anzeigbaren bzw. übertragbaren Listen.
+ * @brief Processes card data into displayable or transferable lists.
  */
 static CardPayloadProcessor cardPayloadProcessor;
 
 /**
- * @brief Zwischenspeicher für die aus einer Karte extrahierten Nutzdaten.
+ * @brief Temporary storage for the payload extracted from a card.
  */
 static std::vector<String> ListElementsInPayloadFromCard;
 
 // Display
 
 /**
- * @brief Manager für die Ausgabe auf dem integrierten T-Display.
+ * @brief Manager responsible for rendering content on the integrated T-Display.
  */
 static DisplayManager displayManager;
 
 /**
- * @brief GPIO des ersten Tasters (Boot-Button).
+ * @brief GPIO of the first button (boot button).
  */
 constexpr int kButtonPin0 = 0;
 
 /**
- * @brief GPIO des zweiten Tasters, dient gleichzeitig als Wake-Up-Quelle.
+ * @brief GPIO of the second button, also used as the wake-up source.
  */
 constexpr int kButtonPin35 = 35;
 
 /**
- * @brief Verwaltung der physischen Taster inklusive Entprellung.
+ * @brief Manages the physical buttons, including debouncing.
  */
 static ButtonManager buttonManager(kButtonPin0, kButtonPin35);
 
 /**
- * @brief Globale Instanz der BLE-Tastaturemulation.
+ * @brief Global instance of the BLE keyboard emulation.
  */
 static BleKeyboardCallback gbleKeyboard;
 
 /**
- * @brief Sendet einen Text über die BLE-Tastatur, sofern eine Verbindung besteht.
+ * @brief Sends text via the BLE keyboard if a connection is established.
  *
- * @param text UTF-8-kodierter Inhalt, der übertragen werden soll.
+ * @param text UTF-8 encoded content to transmit.
  */
 static void SendTextToKeyboard(const String& text)
 {
@@ -141,9 +141,10 @@ static void SendTextToKeyboard(const String& text)
 }
 
 /**
- * @brief Callback bei neuen Kartendaten zur Anzeige und Weitergabe per BLE.
+ * @brief Callback invoked when new card data is available to display and
+ *        forward via BLE.
  *
- * @param payloadText Rohtext der ausgelesenen Karte.
+ * @param payloadText Raw text read from the card.
  */
 static void OnNewData(const String& payloadText)
 {
@@ -157,14 +158,14 @@ static void OnNewData(const String& payloadText)
 
 	Logger::LogInfo(F("Processed card payload values:"));
 
-	for (size_t index = 0; index < ListElementsInPayloadFromCard.size(); ++index)
-	{
-		if (index == 0)
-		{
-			// Ausgabe des Kürzels
-			displayManager.showMessage(ListElementsInPayloadFromCard[index]);
+        for (size_t index = 0; index < ListElementsInPayloadFromCard.size(); ++index)
+        {
+                if (index == 0)
+                {
+                        // Display the primary entry immediately
+                        displayManager.showMessage(ListElementsInPayloadFromCard[index]);
 
-		}
+                }
 		Logger::logf(Logger::Level::Info, "  [%u] %s\n", static_cast<unsigned>(index), ListElementsInPayloadFromCard[index].c_str());
 	}
 
@@ -175,21 +176,21 @@ static void OnNewData(const String& payloadText)
 }
 
 /**
- * @brief Versetzt den ESP32 in den Tiefschlaf und aktiviert Wake-Up über GPIO 35.
+ * @brief Puts the ESP32 into deep sleep and enables wake-up via GPIO 35.
  */
 static void EnterDeepSleep()
 {
-	Logger::LogInfo(F("[System] Entering deep sleep"));
+        Logger::LogInfo(F("[System] Entering deep sleep"));
 	esp_sleep_enable_ext0_wakeup(GPIO_NUM_35, 0);
 	esp_deep_sleep_start();
 }
 
 /**
- * @brief Arduino-Initialisierung: richtet Logger, Anzeige, Kartenleser und BLE ein.
+ * @brief Arduino initialization: sets up the logger, display, card reader, and BLE.
  */
 void setup()
 {
-	Logger::begin(115200, true, Logger::Level::Info);
+        Logger::begin(115200, true, Logger::Level::Info);
 
 	displayManager.begin(DisplayManager::Orientation::UsbLeft);
 	Logger::setDisplayManager(&displayManager);
@@ -206,7 +207,7 @@ void setup()
 }
 
 /**
- * @brief Hauptschleife zum Auswerten der seriellen Schnittstelle und Eingaben.
+ * @brief Main loop handling serial input and user interactions.
  */
 void loop()
 {

--- a/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.cpp
+++ b/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.cpp
@@ -3,8 +3,8 @@
  * File: BleKeyboardCallback.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Implementiert die Logik zum Neustarten des BLE-Advertisings
- *              nach Verbindungsabbrüchen und ergänzt Diagnoseausgaben.
+ * Description: Implements the logic that restarts BLE advertising after
+ *              disconnects and adds diagnostic output.
  ***************************************************************************/
 
 #include "BleKeyboardCallback.h"
@@ -47,6 +47,6 @@ void BleKeyboardCallback::restartAdvertisingIfNecessary()
         Logger::LogError(F("[BLE] Advertising konnte nach Trennung nicht gestartet werden."));
     }
 #else
-    // Klassischer BLE-Stack: das Basismodul übernimmt den Neustart des Advertisings.
+    // Classic BLE stack: the base module takes care of restarting advertising.
 #endif
 }

--- a/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.h
+++ b/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.h
@@ -3,20 +3,20 @@
  * File: BleKeyboardCallback.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Deklaration einer erweiterten BLE-Tastatur, die Verbindungs-
- *              callbacks protokolliert und den Anzeigestatus aktualisiert.
+ * Description: Declares an extended BLE keyboard that logs connection
+ *              callbacks and updates the display state.
  ***************************************************************************/
 
 #pragma once
 
 #include <NimBLEDevice.h> // 2.3.6
-#include <BleKeyboard.h> // Hinweis: Manuell gepatched für NimBLE 2.3.6!
+#include <BleKeyboard.h> // Note: manually patched for NimBLE 2.3.6!
 #include "../Presentation/DisplayManager.h"
 #include "../Logger/Logger.h"
 
 
 /**
- * @brief Spezialisierte Tastaturemulation mit zusätzlichen Logmeldungen.
+ * @brief Specialized keyboard emulation that emits additional log messages.
  */
 class BleKeyboardCallback final : public BleKeyboard
 {

--- a/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.cpp
+++ b/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.cpp
@@ -3,8 +3,8 @@
  * File: CardPayloadProcessor.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Implementiert das Zerlegen von Nutztexten in maximal fünf
- *              bereinigte Werte und protokolliert Sonderfälle der Eingabe.
+ * Description: Implements splitting payload text into up to five sanitized
+ *              values and logs exceptional input conditions.
  ***************************************************************************/
 
 #include "CardPayloadProcessor.h"

--- a/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.h
+++ b/Src/Esp32NMCI/src/CardReader/CardPayloadProcessor.h
@@ -3,8 +3,8 @@
  * File: CardPayloadProcessor.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Deklaration der Hilfsklasse, die Kartennutzdaten in aufbereitete
- *              Listenelemente für Anzeige und BLE-Transfer zerlegt.
+ * Description: Declares the helper class that splits card payload text into
+ *              curated list entries for display and BLE transfer.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
@@ -3,8 +3,8 @@
  * File: CardReaderManager.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Enthält die Laufzeitlogik zur Initialisierung des PN532, zum
- *              Erfassen von Type-2-Tags und zum Weiterreichen der NDEF-Daten.
+ * Description: Contains the runtime logic for initializing the PN532, detecting
+ *              Type 2 tags, and forwarding NDEF data.
  ***************************************************************************/
 
 #include "CardReaderManager.h"
@@ -14,7 +14,7 @@
 
 #include "../Logger/Logger.h"
 
-#define W01 F("W01 Datensatz 1 nicht vorhanden!") // war "Failed to parse first NDEF record"
+#define W01 F("W01 Datensatz 1 nicht vorhanden!") // previously "Failed to parse first NDEF record"
 
 CardReaderManager::CardReaderManager(PN532& nfc, Type2TagReader& tagReader, NdefHelper& ndefHelper)
 	: nfc_(nfc), tagReader_(tagReader), ndefHelper_(ndefHelper)

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
@@ -3,8 +3,8 @@
  * File: CardReaderManager.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Schnittstellendeklaration des Managers, der den PN532 ansteuert,
- *              NFC-Tags verarbeitet und Nutzdaten an Callbacks weitergibt.
+ * Description: Declares the interface of the manager that drives the PN532,
+ *              processes NFC tags, and forwards payload data via callbacks.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/CardReader/NdefHelper.cpp
+++ b/Src/Esp32NMCI/src/CardReader/NdefHelper.cpp
@@ -3,8 +3,8 @@
  * File: NdefHelper.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Stellt die Routinen zum Auffinden und Dekodieren von TLV- und
- *              NDEF-Inhalten bereit, inklusive Ausgabehilfen.
+ * Description: Provides routines for locating and decoding TLV and NDEF
+ *              content, including helper output utilities.
  ***************************************************************************/
 
 #include "NdefHelper.h"

--- a/Src/Esp32NMCI/src/CardReader/NdefHelper.h
+++ b/Src/Esp32NMCI/src/CardReader/NdefHelper.h
@@ -3,8 +3,8 @@
  * File: NdefHelper.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Deklariert Funktionen zum Parsen von TLV- und NDEF-Strukturen
- *              aus den ausgelesenen NFC-Tag-Daten.
+ * Description: Declares functions for parsing TLV and NDEF structures from the
+ *              NFC tag data that has been read.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/CardReader/Type2TagReader.cpp
+++ b/Src/Esp32NMCI/src/CardReader/Type2TagReader.cpp
@@ -3,8 +3,8 @@
  * File: Type2TagReader.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Implementiert das Auslesen von Capability-Container und
- *              Nutzspeicher der Type-2-Tags über den PN532.
+ * Description: Implements reading the capability container and user memory of
+ *              Type 2 tags via the PN532.
  ***************************************************************************/
 
 #include "Type2TagReader.h"

--- a/Src/Esp32NMCI/src/CardReader/Type2TagReader.h
+++ b/Src/Esp32NMCI/src/CardReader/Type2TagReader.h
@@ -3,8 +3,8 @@
  * File: Type2TagReader.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Deklaration eines Readers für MIFARE-Type-2-Tags inklusive
- *              Auslesen des Capability Containers und des Nutzspeichers.
+ * Description: Declares a reader for MIFARE Type 2 tags including reading the
+ *              capability container and user memory.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/Helper/Utf8Decoder.cpp
+++ b/Src/Esp32NMCI/src/Helper/Utf8Decoder.cpp
@@ -3,8 +3,8 @@
  * File: Utf8Decoder.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Liefert die Zustandsmaschine zur UTF-8-Dekodierung für den
- *              zeichenweisen Empfang von Kartendaten.
+ * Description: Provides the state machine used to decode UTF-8 while receiving
+ *              card data one character at a time.
  ***************************************************************************/
 
 #include "Utf8Decoder.h"

--- a/Src/Esp32NMCI/src/Helper/Utf8Decoder.h
+++ b/Src/Esp32NMCI/src/Helper/Utf8Decoder.h
@@ -3,8 +3,8 @@
  * File: Utf8Decoder.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Deklaration eines kleinen Zustandsautomaten zum Streamen und
- *              Dekodieren von UTF-8-Eingabedaten in Unicode-Codepoints.
+ * Description: Declares a lightweight state machine for streaming and decoding
+ *              UTF-8 input data into Unicode code points.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/Logger/Logger.cpp
+++ b/Src/Esp32NMCI/src/Logger/Logger.cpp
@@ -3,8 +3,8 @@
  * File: Logger.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Implementiert die Ausgabe- und Formatierungsfunktionen des
- *              Loggers inklusive Serial-Setup und Displaybenachrichtigung.
+ * Description: Implements the output and formatting routines of the logger,
+ *              including serial setup and display notification.
  ***************************************************************************/
 
 #include "Logger.h"

--- a/Src/Esp32NMCI/src/Logger/Logger.h
+++ b/Src/Esp32NMCI/src/Logger/Logger.h
@@ -3,8 +3,8 @@
  * File: Logger.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Deklariert das Logging-Subsystem mit Anzeigeintegration, das
- *              formatierte Ausgaben verschiedener Schweregrade bereitstellt.
+ * Description: Declares the logging subsystem with display integration that
+ *              provides formatted output across multiple severity levels.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/Presentation/ButtonManager.cpp
+++ b/Src/Esp32NMCI/src/Presentation/ButtonManager.cpp
@@ -3,8 +3,8 @@
  * File: ButtonManager.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Realisiert das zyklische Einlesen der Taster, erkennt Kurz-
- *              und Langdrucke und triggert konfigurierte Aktionen.
+ * Description: Implements the cyclic polling of buttons, detects short and
+ *              long presses, and triggers configured actions.
  ***************************************************************************/
 
 // ButtonManager.cpp

--- a/Src/Esp32NMCI/src/Presentation/ButtonManager.h
+++ b/Src/Esp32NMCI/src/Presentation/ButtonManager.h
@@ -3,8 +3,8 @@
  * File: ButtonManager.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Deklariert die Verwaltung der physischen Taster inklusive
- *              Entprellung, Zustandsabfrage und Callback-Zuweisung.
+ * Description: Declares management of the physical buttons including
+ *              debouncing, state tracking, and callback registration.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
+++ b/Src/Esp32NMCI/src/Presentation/DisplayManager.cpp
@@ -3,8 +3,8 @@
  * File: DisplayManager.cpp
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Implementiert die Darstellung von Meldungen und Overlays auf
- *              dem T-Display einschließlich BLE-Status und Fade-Out-Logik.
+ * Description: Implements message and overlay rendering on the T-Display
+ *              including BLE status handling and fade-out logic.
  ***************************************************************************/
 
 #include <Arduino.h>
@@ -68,7 +68,7 @@ void DisplayManager::renderSingleMessage(const String& message, uint16_t textCol
 {
         clearScreen();
 
-        tft.setTextDatum(MC_DATUM); // Mitte zentriert
+        tft.setTextDatum(MC_DATUM); // Centered both horizontally and vertically
         tft.setTextColor(textColor, currentBackgroundColor);
 
         const uint16_t topArea = calculateOverlayAreaHeight(OverlayPlacement::Top);
@@ -83,8 +83,8 @@ void DisplayManager::renderSingleMessage(const String& message, uint16_t textCol
         const int16_t textAreaTop = static_cast<int16_t>(topArea);
         const int16_t textAreaCenterY = textAreaTop + (textAreaHeight / 2);
 
-        // Maximale Displaygröße
-        int maxWidth = tft.width() - kTextMargin;   // etwas Rand lassen
+        // Maximum render area inside the display
+        int maxWidth = tft.width() - kTextMargin;   // keep a small margin
         int maxHeight = textAreaHeight - kTextMargin;
 
         if (maxHeight < 8)
@@ -93,16 +93,16 @@ void DisplayManager::renderSingleMessage(const String& message, uint16_t textCol
         }
 
         int bestSize = 1;
-        for (int size = 1; size <= 8; ++size) // 1 bis 7 sind vernünftig
+        for (int size = 1; size <= 8; ++size) // sizes 1 through 7 are practical
         {
                 tft.setTextSize(size);
-		int16_t w = tft.textWidth(message);
-		int16_t h = 8 * size;  // Standardhöhe der Schrift bei Größe 1 = 8px
+                int16_t w = tft.textWidth(message);
+                int16_t h = 8 * size;  // default font height at size 1 is 8 px
 
-		if (w > maxWidth || h > maxHeight)
-		{
-			break;  // letzte gültige Größe war bestSize
-		}
+                if (w > maxWidth || h > maxHeight)
+                {
+                        break;  // the previous value of bestSize remains valid
+                }
                 bestSize = size;
         }
 
@@ -393,9 +393,9 @@ void DisplayManager::redrawCachedMessage()
 }
 
 /*
-        Prüft ob die Zeit abgelaufen ist um das Display auszugrauen.
+        Checks whether it is time to dim the display content.
 
-        @see kDisplayManager_TimeToFadeOutDisplay Konfiguration des Delay bis zum Ausgrauen
+        @see kDisplayManager_TimeToFadeOutDisplay configuration for the fade-out delay
 */
 void DisplayManager::update()
 {

--- a/Src/Esp32NMCI/src/Presentation/DisplayManager.h
+++ b/Src/Esp32NMCI/src/Presentation/DisplayManager.h
@@ -3,8 +3,8 @@
  * File: DisplayManager.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Deklariert die Ansteuerung des T-Display-Displays inklusive
- *              Overlayverwaltung, BLE-Statusanzeige und Nachrichtencache.
+ * Description: Declares the rendering control for the T-Display including
+ *              overlay management, BLE status indicators, and message caching.
  ***************************************************************************/
 
 #pragma once

--- a/Src/Esp32NMCI/src/config.h
+++ b/Src/Esp32NMCI/src/config.h
@@ -3,15 +3,15 @@
  * File: config.h
  * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
  * Author: Peter Heß, Büdingen DE
- * Description: Zentrale Konfigurationswerte für Pins, Geschwindigkeiten und
- *              Grenzwerte des NFC-Lesers sowie Anzeigeparameter.
+ * Description: Central configuration values for pins, speeds, NFC reader
+ *              thresholds, and display parameters.
  ***************************************************************************/
 
 #pragma once
 
 #include <stdint.h>
 
-// Splashtext
+// Splash text shown during startup
 #define VERSION_TEXT "NMCI V1.1"
 
 // Serial port used to communicate with the PN532 module over High Speed UART.
@@ -33,5 +33,5 @@ constexpr uint8_t kUidBufferMax = 10;
 constexpr uint16_t kUserMaxBytes = 1024;
 
 
-// DisplayManagerZeit in Ms bis das Display "ausgraut"
+// Duration in milliseconds before the DisplayManager dims the content
 constexpr uint32_t kDisplayManager_TimeToFadeOutDisplay = 5000U;


### PR DESCRIPTION
## Summary
- translate file headers and inline comments in the Esp32NMCI sketch and supporting modules to English
- update display manager notes to explain layout logic and fade-out timing in English
- align configuration and BLE helper comments with the new English documentation standard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7cdd286008323b90a30ea40879916