### PR TITLE
Remove legacy BLE stack branches and require NimBLE

### DIFF
--- a/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/0.3.2/ESP32-BLE-Keyboard/BleKeyboard.cpp
+++ b/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/0.3.2/ESP32-BLE-Keyboard/BleKeyboard.cpp
@@ -1,17 +1,8 @@
 #include "BleKeyboard.h"
-
-#if defined(USE_NIMBLE)
 #include <NimBLEDevice.h>
 #include <NimBLEServer.h>
 #include <NimBLEUtils.h>
 #include <NimBLEHIDDevice.h>
-#else
-#include <BLEDevice.h>
-#include <BLEUtils.h>
-#include <BLEServer.h>
-#include "BLE2902.h"
-#include "BLEHIDDevice.h"
-#endif // USE_NIMBLE
 #include "HIDTypes.h"
 #include <driver/adc.h>
 #include "sdkconfig.h"
@@ -121,16 +112,7 @@ void BleKeyboard::begin(void)
 	hid->setHidInfo(0x00, 0x01);
 
 
-#if defined(USE_NIMBLE)
-
-	BLEDevice::setSecurityAuth(true, true, true);
-
-#else
-
-	BLESecurity* pSecurity = new BLESecurity();
-	pSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_MITM_BOND);
-
-#endif // USE_NIMBLE
+        BLEDevice::setSecurityAuth(true, true, true);
 
 	hid->setReportMap((uint8_t*)_hidReportDescriptor, sizeof(_hidReportDescriptor));
 	hid->startServices();
@@ -192,11 +174,8 @@ void BleKeyboard::sendReport(KeyReport* keys)
 	if (this->isConnected())
 	{
 		this->inputKeyboard->setValue((uint8_t*)keys, sizeof(KeyReport));
-		this->inputKeyboard->notify();
-#if defined(USE_NIMBLE)        
-		// vTaskDelay(delayTicks);
-		this->delay_ms(_delay_ms);
-#endif // USE_NIMBLE
+                this->inputKeyboard->notify();
+                this->delay_ms(_delay_ms);
 	}
 }
 
@@ -205,11 +184,8 @@ void BleKeyboard::sendReport(MediaKeyReport* keys)
 	if (this->isConnected())
 	{
 		this->inputMediaKeys->setValue((uint8_t*)keys, sizeof(MediaKeyReport));
-		this->inputMediaKeys->notify();
-#if defined(USE_NIMBLE)        
-		//vTaskDelay(delayTicks);
-		this->delay_ms(_delay_ms);
-#endif // USE_NIMBLE
+                this->inputMediaKeys->notify();
+                this->delay_ms(_delay_ms);
 	}
 }
 
@@ -505,66 +481,24 @@ size_t BleKeyboard::write(const uint8_t* buffer, size_t size) {
 	return n;
 }
 
-#if defined(USE_NIMBLE)
-
 void BleKeyboard::onConnect(BLEServer* pServer, NimBLEConnInfo& connInfo) {
-
-#else // USE_NIMBLE
-
-void BleKeyboard::onConnect(BLEServer * pServer) {
-
-#endif  // USE_NIMBLE
-
-	this->connected = true;
-
-#if !defined(USE_NIMBLE)
-
-	BLE2902* desc = (BLE2902*)this->inputKeyboard->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
-	desc->setNotifications(true);
-	desc = (BLE2902*)this->inputMediaKeys->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
-	desc->setNotifications(true);
-
-#endif // !USE_NIMBLE
-
+        (void)pServer;
+        (void)connInfo;
+        this->connected = true;
 }
 
-#if defined(USE_NIMBLE)
-
-void BleKeyboard::onDisconnect(BLEServer * pServer, NimBLEConnInfo & connInfo, int reason) {
-
-#else // USE_NIMBLE
-
-void BleKeyboard::onDisconnect(BLEServer * pServer) {
-
-#endif  // USE_NIMBLE
-
-	this->connected = false;
-
-#if !defined(USE_NIMBLE)
-
-	BLE2902* desc = (BLE2902*)this->inputKeyboard->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
-	desc->setNotifications(false);
-	desc = (BLE2902*)this->inputMediaKeys->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
-	desc->setNotifications(false);
-
-	advertising->start();
-
-#endif // !USE_NIMBLE
+void BleKeyboard::onDisconnect(BLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
+        (void)pServer;
+        (void)connInfo;
+        (void)reason;
+        this->connected = false;
 }
 
-
-#if defined(USE_NIMBLE)
-
-void BleKeyboard::onWrite(BLECharacteristic * me, NimBLEConnInfo & connInfo) {
-
-#else // USE_NIMBLE
-
-void BleKeyboard::onWrite(BLECharacteristic * me) {
-
-#endif  // USE_NIMBLE
-	uint8_t* value = (uint8_t*)(me->getValue().c_str());
-	(void)value;
-	ESP_LOGI(LOG_TAG, "special keys: %d", *value);
+void BleKeyboard::onWrite(BLECharacteristic* me, NimBLEConnInfo& connInfo) {
+        (void)connInfo;
+        uint8_t* value = (uint8_t*)(me->getValue().c_str());
+        (void)value;
+        ESP_LOGI(LOG_TAG, "special keys: %d", *value);
 }
 
 

--- a/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/0.3.2/ESP32-BLE-Keyboard/BleKeyboard.h
+++ b/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/0.3.2/ESP32-BLE-Keyboard/BleKeyboard.h
@@ -1,13 +1,9 @@
-// uncomment the following line to use NimBLE library
-#define USE_NIMBLE
-
 #ifndef ESP32_BLE_KEYBOARD_H
 #define ESP32_BLE_KEYBOARD_H
 #include "sdkconfig.h"
 #if defined(CONFIG_BT_ENABLED)
 
-#if defined(USE_NIMBLE)
-
+#include "NimBLEDevice.h"
 #include "NimBLECharacteristic.h"
 #include "NimBLEHIDDevice.h"
 #include "NimBLEAdvertising.h"
@@ -20,13 +16,6 @@
 #define BLECharacteristic          NimBLECharacteristic
 #define BLEAdvertising             NimBLEAdvertising
 #define BLEServer                  NimBLEServer
-
-#else
-
-#include "BLEHIDDevice.h"
-#include "BLECharacteristic.h"
-
-#endif // USE_NIMBLE
 
 #include "Print.h"
 
@@ -175,20 +164,9 @@ public:
   void set_version(uint16_t version);
 protected:
   virtual void onStarted(BLEServer *pServer) { };
-
-#if defined(USE_NIMBLE)
-
   virtual void onConnect(BLEServer* pServer, NimBLEConnInfo& connInfo) override;
   virtual void onDisconnect(BLEServer* pServer, NimBLEConnInfo& connInfo, int reason) override;
   virtual void onWrite(BLECharacteristic* me, NimBLEConnInfo& connInfo) override;
-
-#else  // USE_NIMBLE
-
-  virtual void onConnect(BLEServer* pServer) override;
-  virtual void onDisconnect(BLEServer* pServer) override;
-  virtual void onWrite(BLECharacteristic* me) override;
-
-#endif  // USE_NIMBLE
 
 };
 

--- a/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/BleKeyboard.cpp
+++ b/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/BleKeyboard.cpp
@@ -1,17 +1,8 @@
 #include "BleKeyboard.h"
-
-#if defined(USE_NIMBLE)
 #include <NimBLEDevice.h>
 #include <NimBLEServer.h>
 #include <NimBLEUtils.h>
 #include <NimBLEHIDDevice.h>
-#else
-#include <BLEDevice.h>
-#include <BLEUtils.h>
-#include <BLEServer.h>
-#include "BLE2902.h"
-#include "BLEHIDDevice.h"
-#endif // USE_NIMBLE
 #include "HIDTypes.h"
 #include <driver/adc.h>
 #include "sdkconfig.h"
@@ -120,16 +111,7 @@ void BleKeyboard::begin(void)
   hid->hidInfo(0x00, 0x01);
 
 
-#if defined(USE_NIMBLE)
-
   BLEDevice::setSecurityAuth(true, true, true);
-
-#else
-
-  BLESecurity* pSecurity = new BLESecurity();
-  pSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_MITM_BOND);
-
-#endif // USE_NIMBLE
 
   hid->reportMap((uint8_t*)_hidReportDescriptor, sizeof(_hidReportDescriptor));
   hid->startServices();
@@ -192,10 +174,7 @@ void BleKeyboard::sendReport(KeyReport* keys)
   {
     this->inputKeyboard->setValue((uint8_t*)keys, sizeof(KeyReport));
     this->inputKeyboard->notify();
-#if defined(USE_NIMBLE)        
-    // vTaskDelay(delayTicks);
     this->delay_ms(_delay_ms);
-#endif // USE_NIMBLE
   }	
 }
 
@@ -205,10 +184,7 @@ void BleKeyboard::sendReport(MediaKeyReport* keys)
   {
     this->inputMediaKeys->setValue((uint8_t*)keys, sizeof(MediaKeyReport));
     this->inputMediaKeys->notify();
-#if defined(USE_NIMBLE)        
-    //vTaskDelay(delayTicks);
     this->delay_ms(_delay_ms);
-#endif // USE_NIMBLE
   }	
 }
 
@@ -499,36 +475,21 @@ size_t BleKeyboard::write(const uint8_t *buffer, size_t size) {
 	return n;
 }
 
-void BleKeyboard::onConnect(BLEServer* pServer) {
+void BleKeyboard::onConnect(BLEServer* pServer, NimBLEConnInfo& connInfo) {
+  (void)pServer;
+  (void)connInfo;
   this->connected = true;
-
-#if !defined(USE_NIMBLE)
-
-  BLE2902* desc = (BLE2902*)this->inputKeyboard->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
-  desc->setNotifications(true);
-  desc = (BLE2902*)this->inputMediaKeys->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
-  desc->setNotifications(true);
-
-#endif // !USE_NIMBLE
-
 }
 
-void BleKeyboard::onDisconnect(BLEServer* pServer) {
+void BleKeyboard::onDisconnect(BLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
+  (void)pServer;
+  (void)connInfo;
+  (void)reason;
   this->connected = false;
-
-#if !defined(USE_NIMBLE)
-
-  BLE2902* desc = (BLE2902*)this->inputKeyboard->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
-  desc->setNotifications(false);
-  desc = (BLE2902*)this->inputMediaKeys->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
-  desc->setNotifications(false);
-
-  advertising->start();
-
-#endif // !USE_NIMBLE
 }
 
-void BleKeyboard::onWrite(BLECharacteristic* me) {
+void BleKeyboard::onWrite(BLECharacteristic* me, NimBLEConnInfo& connInfo) {
+  (void)connInfo;
   uint8_t* value = (uint8_t*)(me->getValue().c_str());
   (void)value;
   ESP_LOGI(LOG_TAG, "special keys: %d", *value);

--- a/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/BleKeyboard.h
+++ b/Src/Esp32NMCI/Libraries/ESP32-BLE-Keyboard/BleKeyboard.h
@@ -1,13 +1,9 @@
-// uncomment the following line to use NimBLE library
-//#define USE_NIMBLE
-
 #ifndef ESP32_BLE_KEYBOARD_H
 #define ESP32_BLE_KEYBOARD_H
 #include "sdkconfig.h"
 #if defined(CONFIG_BT_ENABLED)
 
-#if defined(USE_NIMBLE)
-
+#include "NimBLEDevice.h"
 #include "NimBLECharacteristic.h"
 #include "NimBLEHIDDevice.h"
 
@@ -18,13 +14,6 @@
 #define BLECharacteristic          NimBLECharacteristic
 #define BLEAdvertising             NimBLEAdvertising
 #define BLEServer                  NimBLEServer
-
-#else
-
-#include "BLEHIDDevice.h"
-#include "BLECharacteristic.h"
-
-#endif // USE_NIMBLE
 
 #include "Print.h"
 
@@ -173,9 +162,9 @@ public:
   void set_version(uint16_t version);
 protected:
   virtual void onStarted(BLEServer *pServer) { };
-  virtual void onConnect(BLEServer* pServer) override;
-  virtual void onDisconnect(BLEServer* pServer) override;
-  virtual void onWrite(BLECharacteristic* me) override;
+  virtual void onConnect(BLEServer* pServer, NimBLEConnInfo& connInfo) override;
+  virtual void onDisconnect(BLEServer* pServer, NimBLEConnInfo& connInfo, int reason) override;
+  virtual void onWrite(BLECharacteristic* me, NimBLEConnInfo& connInfo) override;
 
 };
 

--- a/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.cpp
+++ b/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.cpp
@@ -8,14 +8,10 @@
  ***************************************************************************/
 
 #include "BleKeyboardCallback.h"
-
-#if defined(USE_NIMBLE)
 #include <NimBLEAdvertising.h>
-#endif
 
 void BleKeyboardCallback::restartAdvertisingIfNecessary()
 {
-#if defined(USE_NIMBLE)
     NimBLEAdvertising* advertising = BLEDevice::getAdvertising();
 
     if (advertising == nullptr)
@@ -46,7 +42,4 @@ void BleKeyboardCallback::restartAdvertisingIfNecessary()
     {
         Logger::LogError(F("[BLE] Advertising konnte nach Trennung nicht gestartet werden."));
     }
-#else
-    // Classic BLE stack: the base module takes care of restarting advertising.
-#endif
 }

--- a/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.h
+++ b/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.h
@@ -34,7 +34,6 @@ public:
     }
 
 protected:
-#if defined(USE_NIMBLE)
     void onConnect(BLEServer* server, NimBLEConnInfo& connInfo) override
     {
         BleKeyboard::onConnect(server, connInfo);
@@ -57,28 +56,6 @@ protected:
         }
         restartAdvertisingIfNecessary();
     }
-#else
-    void onConnect(BLEServer* server) override
-    {
-        BleKeyboard::onConnect(server);
-        Logger::LogInfo(F("[BLE] Verbindung hergestellt."));
-        if (displayManager != nullptr)
-        {
-            displayManager->setBleConnectionState(true);
-        }
-    }
-
-    void onDisconnect(BLEServer* server) override
-    {
-        BleKeyboard::onDisconnect(server);
-        Logger::LogInfo(F("[BLE] Verbindung getrennt."));
-        if (displayManager != nullptr)
-        {
-            displayManager->setBleConnectionState(false);
-        }
-        restartAdvertisingIfNecessary();
-    }
-#endif
 
 private:
     void restartAdvertisingIfNecessary();


### PR DESCRIPTION
## Summary
- remove the non-NimBLE callback variants and advertising fallback from the BLE keyboard wrapper
- require NimBLE headers and override signatures throughout the bundled BLE keyboard libraries (including the 0.3.2 copy)

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7e33c57988323bbd94fa3e64b5300