### PR TITLE
Translate remaining runtime strings to English

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -202,7 +202,7 @@ void setup()
 	buttonManager.setOnButton35LongPressed(EnterDeepSleep);
 
 	Serial.println();
-	Serial.println(F("[BOOT] ESP32 BLE-HID Keyboard (DE) – Boot-Protocol-First"));
+        Serial.println(F("[BOOT] ESP32 BLE-HID Keyboard (DE) - Boot-Protocol-First"));
 	gbleKeyboard.begin();
 }
 
@@ -217,14 +217,14 @@ void loop()
 
 		if (!gbleKeyboard.isConnected())
 		{
-			if (b <= 0x7F)
-			{
-				Serial.printf("[WARN] Nicht verbunden: '%c' (0x%02X)\n", static_cast<char>(b), static_cast<unsigned>(b));
-			}
-			else
-			{
-				Serial.printf("[WARN] Nicht verbunden: U+%04lX\n", static_cast<unsigned long>(b));
-			}
+                        if (b <= 0x7F)
+                        {
+                                Serial.printf("[WARN] Not connected: '%c' (0x%02X)\n", static_cast<char>(b), static_cast<unsigned>(b));
+                        }
+                        else
+                        {
+                                Serial.printf("[WARN] Not connected: U+%04lX\n", static_cast<unsigned long>(b));
+                        }
 			continue;
 		}
 		gbleKeyboard.print(b);

--- a/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.cpp
+++ b/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.cpp
@@ -16,30 +16,30 @@ void BleKeyboardCallback::restartAdvertisingIfNecessary()
 
     if (advertising == nullptr)
     {
-        Logger::LogWarn(F("[BLE] Kein Advertising-Objekt verfügbar; versuche Neustart."));
+        Logger::LogWarn(F("[BLE] No advertising object available; attempting restart."));
         if (BLEDevice::startAdvertising())
         {
-            Logger::LogInfo(F("[BLE] Advertising im Fallback erfolgreich gestartet."));
+            Logger::LogInfo(F("[BLE] Advertising started successfully using fallback."));
         }
         else
         {
-            Logger::LogError(F("[BLE] Advertising konnte im Fallback nicht gestartet werden."));
+            Logger::LogError(F("[BLE] Failed to start advertising using fallback."));
         }
         return;
     }
 
     if (advertising->isAdvertising())
     {
-        Logger::LogDebug(F("[BLE] Advertising läuft bereits; kein Neustart erforderlich."));
+        Logger::LogDebug(F("[BLE] Advertising already running; no restart required."));
         return;
     }
 
     if (advertising->start())
     {
-        Logger::LogInfo(F("[BLE] Advertising nach Trennung neu gestartet."));
+        Logger::LogInfo(F("[BLE] Advertising restarted after disconnection."));
     }
     else
     {
-        Logger::LogError(F("[BLE] Advertising konnte nach Trennung nicht gestartet werden."));
+        Logger::LogError(F("[BLE] Failed to restart advertising after disconnection."));
     }
 }

--- a/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.h
+++ b/Src/Esp32NMCI/src/Ble/BleKeyboardCallback.h
@@ -37,7 +37,7 @@ protected:
     void onConnect(BLEServer* server, NimBLEConnInfo& connInfo) override
     {
         BleKeyboard::onConnect(server, connInfo);
-        Logger::LogInfo(F("[BLE] Verbindung hergestellt."));
+        Logger::LogInfo(F("[BLE] Connection established."));
         if (displayManager != nullptr)
         {
             displayManager->setBleConnectionState(true);
@@ -48,7 +48,7 @@ protected:
     {
         BleKeyboard::onDisconnect(server, connInfo, reason);
         Logger::logf(Logger::Level::Info,
-            "[BLE] Verbindung getrennt (Grund: %d).\n",
+            "[BLE] Disconnected (reason: %d).\n",
             reason);
         if (displayManager != nullptr)
         {

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
@@ -14,7 +14,7 @@
 
 #include "../Logger/Logger.h"
 
-#define W01 F("W01 Datensatz 1 nicht vorhanden!") // previously "Failed to parse first NDEF record"
+#define W01 F("W01 Record 1 not available!") // previously "Failed to parse first NDEF record"
 
 CardReaderManager::CardReaderManager(PN532& nfc, Type2TagReader& tagReader, NdefHelper& ndefHelper)
 	: nfc_(nfc), tagReader_(tagReader), ndefHelper_(ndefHelper)
@@ -115,7 +115,7 @@ void CardReaderManager::handleTagDetected(const uint8_t* uid, uint8_t uidLength)
 
 	if (!ti.ccValid)
 	{
-		Logger::LogWarn(F("Warning: CC Magic != 0xE1 (evtl. kein NDEF-Tag oder CC korrupt)"));
+                Logger::LogWarn(F("Warning: CC Magic != 0xE1 (possibly not an NDEF tag or CC corrupted)"));
 	}
 
 	Logger::LogDebug(F("Probable type: "));


### PR DESCRIPTION
## Summary
- translate the remaining German BLE diagnostic messages and CC warning text to English
- update serial boot and warning output to use English wording

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7e5b21c348323b8fdb2bf34ab90ab