### PR TITLE
Extract deep sleep helper

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -41,7 +41,6 @@
 
 // Miscellaneous helpers :-)
 #include <vector>
-#include <esp_sleep.h>
 
 // Implementation
 #include "src/config.h"
@@ -53,6 +52,7 @@
 #include "src/Presentation/DisplayManager.h"
 #include "src/Presentation/ButtonManager.h"
 #include "src/Helper/Utf8Decoder.h"
+#include "src/Helper/SystemHelper.h"
 #include "src/Ble/BleKeyboardCallback.h"
 
 // Card reader
@@ -176,16 +176,6 @@ static void OnNewData(const String& payloadText)
 }
 
 /**
- * @brief Puts the ESP32 into deep sleep and enables wake-up via GPIO 35.
- */
-static void EnterDeepSleep()
-{
-        Logger::LogInfo(F("[System] Entering deep sleep"));
-	esp_sleep_enable_ext0_wakeup(GPIO_NUM_35, 0);
-	esp_deep_sleep_start();
-}
-
-/**
  * @brief Arduino initialization: sets up the logger, display, card reader, and BLE.
  */
 void setup()
@@ -198,8 +188,8 @@ void setup()
 
 	cardReaderManager.setNewDataCallback(OnNewData);
 	cardReaderManager.begin();
-	buttonManager.begin();
-	buttonManager.setOnButton35LongPressed(EnterDeepSleep);
+        buttonManager.begin();
+        buttonManager.setOnButton35LongPressed(SystemHelper::EnterDeepSleep);
 
 	Serial.println();
         Serial.println(F("[BOOT] ESP32 BLE-HID Keyboard (DE) - Boot-Protocol-First"));

--- a/Src/Esp32NMCI/src/Helper/SystemHelper.cpp
+++ b/Src/Esp32NMCI/src/Helper/SystemHelper.cpp
@@ -1,0 +1,21 @@
+/***************************************************************************
+ * Project: Esp32NMCI
+ * File: SystemHelper.cpp
+ * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
+ * Author: Peter Heß, Büdingen DE
+ * Description: Implements helper utilities for interacting with ESP32 system
+ *              features such as deep sleep handling.
+ ***************************************************************************/
+
+#include "SystemHelper.h"
+
+#include <esp_sleep.h>
+
+#include "src/Logger/Logger.h"
+
+void SystemHelper::EnterDeepSleep()
+{
+        Logger::LogInfo(F("[System] Entering deep sleep"));
+        esp_sleep_enable_ext0_wakeup(GPIO_NUM_35, 0);
+        esp_deep_sleep_start();
+}

--- a/Src/Esp32NMCI/src/Helper/SystemHelper.h
+++ b/Src/Esp32NMCI/src/Helper/SystemHelper.h
@@ -1,0 +1,22 @@
+/***************************************************************************
+ * Project: Esp32NMCI
+ * File: SystemHelper.h
+ * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
+ * Author: Peter Heß, Büdingen DE
+ * Description: Declares helper utilities for interacting with ESP32 system
+ *              features such as deep sleep handling.
+ ***************************************************************************/
+
+#pragma once
+
+/**
+ * @brief Utility helpers for system level features of the ESP32.
+ */
+class SystemHelper
+{
+    public:
+    /**
+     * @brief Puts the ESP32 into deep sleep and enables wake-up via GPIO 35.
+     */
+    static void EnterDeepSleep();
+};


### PR DESCRIPTION
## Summary
- add a SystemHelper utility under Helper/ to encapsulate deep sleep logic
- include and use SystemHelper::EnterDeepSleep from the main sketch, replacing the previous static function

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7eade06008323a4fae599f396c1ce