### PR TITLE
Extract BLE keyboard helper

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -54,6 +54,7 @@
 #include "src/Helper/Utf8Decoder.h"
 #include "src/Helper/SystemHelper.h"
 #include "src/Ble/BleKeyboardCallback.h"
+#include "src/Ble/BleHelper.h"
 
 // Card reader
 
@@ -120,27 +121,6 @@ static ButtonManager buttonManager(kButtonPin0, kButtonPin35);
 static BleKeyboardCallback gbleKeyboard;
 
 /**
- * @brief Sends text via the BLE keyboard if a connection is established.
- *
- * @param text UTF-8 encoded content to transmit.
- */
-static void SendTextToKeyboard(const String& text)
-{
-	if (text.length() == 0)
-	{
-		return;
-	}
-
-	if (!gbleKeyboard.isConnected())
-	{
-		Logger::LogWarn(F("BLE keyboard not connected; skipping payload transfer."));
-		return;
-	}
-
-	gbleKeyboard.print(text);
-}
-
-/**
  * @brief Callback invoked when new card data is available to display and
  *        forward via BLE.
  *
@@ -171,7 +151,7 @@ static void OnNewData(const String& payloadText)
 
 	displayManager.showMessage(ListElementsInPayloadFromCard);
 
-	SendTextToKeyboard(ListElementsInPayloadFromCard.front());
+        BleHelper::SendTextToKeyboard(gbleKeyboard, ListElementsInPayloadFromCard.front());
 
 }
 

--- a/Src/Esp32NMCI/Esp32NMCI.vcxproj
+++ b/Src/Esp32NMCI/Esp32NMCI.vcxproj
@@ -85,6 +85,7 @@
       <FileType>CppCode</FileType>
       <DeploymentContent>true</DeploymentContent>
     </ClCompile>
+    <ClCompile Include="src\Ble\BleHelper.cpp" />
     <ClCompile Include="src\Ble\BleKeyboardCallback.cpp" />
     <ClCompile Include="src\CardReader\CardReaderManager.cpp" />
     <ClCompile Include="src\CardReader\CardPayloadProcessor.cpp" />
@@ -96,6 +97,7 @@
     <ClCompile Include="src\Helper\Utf8Decoder.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\Ble\BleHelper.h" />
     <ClInclude Include="src\Ble\BleKeyboardCallback.h" />
     <ClInclude Include="src\CardReader\CardReaderManager.h" />
     <ClInclude Include="src\CardReader\CardPayloadProcessor.h" />

--- a/Src/Esp32NMCI/Esp32NMCI.vcxproj.filters
+++ b/Src/Esp32NMCI/Esp32NMCI.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="src\Helper\Utf8Decoder.cpp">
       <Filter>Src\Helper</Filter>
     </ClCompile>
+    <ClCompile Include="src\Ble\BleHelper.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
     <ClCompile Include="src\Ble\BleKeyboardCallback.cpp">
       <Filter>Src</Filter>
     </ClCompile>
@@ -86,6 +89,7 @@
     <ClInclude Include="src\Helper\Utf8Decoder.h">
       <Filter>Src\Helper</Filter>
     </ClInclude>
+    <ClInclude Include="src\Ble\BleHelper.h" />
     <ClInclude Include="src\Ble\BleKeyboardCallback.h" />
   </ItemGroup>
 </Project>

--- a/Src/Esp32NMCI/src/Ble/BleHelper.cpp
+++ b/Src/Esp32NMCI/src/Ble/BleHelper.cpp
@@ -1,0 +1,28 @@
+/***************************************************************************
+ * Project: Esp32NMCI
+ * File: BleHelper.cpp
+ * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
+ * Author: Peter Heß, Büdingen DE
+ * Description: Implements helper utilities for BLE keyboard interactions.
+ ***************************************************************************/
+
+#include "BleHelper.h"
+
+#include "src/Ble/BleKeyboardCallback.h"
+#include "src/Logger/Logger.h"
+
+void BleHelper::SendTextToKeyboard(BleKeyboardCallback& keyboard, const String& text)
+{
+        if (text.length() == 0)
+        {
+                return;
+        }
+
+        if (!keyboard.isConnected())
+        {
+                Logger::LogWarn(F("BLE keyboard not connected; skipping payload transfer."));
+                return;
+        }
+
+        keyboard.print(text);
+}

--- a/Src/Esp32NMCI/src/Ble/BleHelper.h
+++ b/Src/Esp32NMCI/src/Ble/BleHelper.h
@@ -1,0 +1,28 @@
+/***************************************************************************
+ * Project: Esp32NMCI
+ * File: BleHelper.h
+ * Repository: https://github.com/hesspet/NasrredinsMagicCardIdentifier
+ * Author: Peter Heß, Büdingen DE
+ * Description: Declares helper utilities for BLE keyboard interactions.
+ ***************************************************************************/
+
+#pragma once
+
+#include <Arduino.h>
+
+class BleKeyboardCallback;
+
+/**
+ * @brief Helper functions related to BLE communication.
+ */
+class BleHelper
+{
+    public:
+    /**
+     * @brief Sends text via the provided BLE keyboard if a connection is established.
+     *
+     * @param keyboard BLE keyboard instance used to transmit the text.
+     * @param text UTF-8 encoded content to transmit.
+     */
+    static void SendTextToKeyboard(BleKeyboardCallback& keyboard, const String& text);
+};


### PR DESCRIPTION
## Summary
- add a dedicated `BleHelper` class to encapsulate BLE keyboard text sending
- use the helper from the main sketch to transmit card payloads
- register the new helper files in the Visual Studio project and filter configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7ec54ca2883238524ca8c1e4caf5c