### PR TITLE
Allow providing card data callback during begin

### DIFF
--- a/Src/Esp32NMCI/Esp32NMCI.ino
+++ b/Src/Esp32NMCI/Esp32NMCI.ino
@@ -167,8 +167,7 @@ void setup()
 	
 	_bleKeyboardCallbackHandler.setDisplayManager(&_displayManager);
 
-	_cardReaderManager.setNewDataCallback(OnNewData);
-	_cardReaderManager.begin();
+        _cardReaderManager.begin(OnNewData);
 	_buttonManager.begin();
 	_buttonManager.setOnButton35LongPressed(SystemHelper::EnterDeepSleep);
 

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.cpp
@@ -26,10 +26,15 @@ void CardReaderManager::setNewDataCallback(NewDataCallback callback)
 	newDataCallback_ = callback;
 }
 
-void CardReaderManager::begin()
+void CardReaderManager::begin(NewDataCallback callback)
 {
-	PN532_HSU_PORT.begin(PN532_HSU_BAUDRATE, SERIAL_8N1, PN532_HSU_RX_PIN, PN532_HSU_TX_PIN);
-	nfc_.begin();
+        if (callback != nullptr)
+        {
+                setNewDataCallback(callback);
+        }
+
+        PN532_HSU_PORT.begin(PN532_HSU_BAUDRATE, SERIAL_8N1, PN532_HSU_RX_PIN, PN532_HSU_TX_PIN);
+        nfc_.begin();
 
 	uint32_t versiondata = nfc_.getFirmwareVersion();
 	if (!versiondata)

--- a/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
+++ b/Src/Esp32NMCI/src/CardReader/CardReaderManager.h
@@ -24,7 +24,7 @@ public:
 
 	CardReaderManager(PN532& nfc, Type2TagReader& tagReader, NdefHelper& ndefHelper);
 
-	void begin();
+        void begin(NewDataCallback callback = nullptr);
 	void process();
 
 	void setNewDataCallback(NewDataCallback callback);


### PR DESCRIPTION
## Summary
- add an optional callback parameter to `CardReaderManager::begin`
- wire setup to register the NFC payload callback through `begin`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7f1e418988323b973d67a7e5accd0