### PR TITLE
Add Blazor routing and layout scaffolding

### DIFF
--- a/NCS-TEST1/App.razor
+++ b/NCS-TEST1/App.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="@typeof(MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(MainLayout)">
+            <p>Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/NCS-TEST1/Shared/MainLayout.razor
+++ b/NCS-TEST1/Shared/MainLayout.razor
@@ -1,0 +1,11 @@
+@inherits LayoutComponentBase
+
+<main class="main-layout">
+    <article class="content">
+        @Body
+    </article>
+</main>
+
+@code {
+    // Placeholder for layout-specific logic.
+}

--- a/NCS-TEST1/_Imports.razor
+++ b/NCS-TEST1/_Imports.razor
@@ -1,0 +1,10 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.JSInterop
+@using NCS_TEST1
+@using NCS_TEST1.Shared


### PR DESCRIPTION
## Summary
- add a standard router configuration for the Blazor app
- introduce a basic shared `MainLayout` component
- add common Razor imports for the project namespace

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa476bc148323a25b0a69f445ce87