### PR TITLE
Fix layout type references in App component

### DIFF
--- a/NCS-TEST1/App.razor
+++ b/NCS-TEST1/App.razor
@@ -1,9 +1,9 @@
 <Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">
-        <RouteView RouteData="routeData" DefaultLayout="@typeof(MainLayout)" />
+        <RouteView RouteData="routeData" DefaultLayout="@typeof(NCS_TEST1.Shared.MainLayout)" />
     </Found>
     <NotFound>
-        <LayoutView Layout="@typeof(MainLayout)">
+        <LayoutView Layout="@typeof(NCS_TEST1.Shared.MainLayout)">
             <p>Sorry, there's nothing at this address.</p>
         </LayoutView>
     </NotFound>


### PR DESCRIPTION
## Summary
- reference the MainLayout type in App.razor using its full namespace so the component resolves during compilation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfaec4925c8323a4bdef8e1a531628